### PR TITLE
Fix stdio buffering

### DIFF
--- a/lib/os/ffi/Cargo.lock
+++ b/lib/os/ffi/Cargo.lock
@@ -225,6 +225,7 @@ checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
 name = "os"
 version = "0.1.0"
 dependencies = [
+ "once_cell",
  "pen-ffi",
  "rand",
  "tokio",

--- a/lib/os/ffi/library/Cargo.toml
+++ b/lib/os/ffi/library/Cargo.toml
@@ -9,6 +9,7 @@ crate-type = ["staticlib"]
 
 [dependencies]
 ffi = { package = "pen-ffi", version = "0.3" }
+once_cell = "1.9.0"
 rand = "0.8"
 # Feature flags of tokio must match the ones in the application crate for its
 # object files to be considered from the same crate.

--- a/lib/os/ffi/library/src/stdio.rs
+++ b/lib/os/ffi/library/src/stdio.rs
@@ -1,6 +1,15 @@
 use super::utilities;
 use crate::result::FfiResult;
-use tokio::io::{stderr, stdin, stdout};
+use core::ops::DerefMut;
+use once_cell::sync::Lazy;
+use tokio::{
+    io::{stderr, stdin, stdout, Stderr, Stdin, Stdout},
+    sync::Mutex,
+};
+
+static STDIN: Lazy<Mutex<Stdin>> = Lazy::new(|| Mutex::new(stdin()));
+static STDOUT: Lazy<Mutex<Stdout>> = Lazy::new(|| Mutex::new(stdout()));
+static STDERR: Lazy<Mutex<Stderr>> = Lazy::new(|| Mutex::new(stderr()));
 
 #[ffi::bindgen]
 async fn _pen_os_read_stdin() -> ffi::Arc<FfiResult<ffi::ByteString>> {
@@ -10,7 +19,7 @@ async fn _pen_os_read_stdin() -> ffi::Arc<FfiResult<ffi::ByteString>> {
 #[ffi::bindgen]
 async fn _pen_os_read_limit_stdin(limit: ffi::Number) -> ffi::Arc<FfiResult<ffi::ByteString>> {
     ffi::Arc::new(
-        utilities::read_limit(&mut stdin(), f64::from(limit) as usize)
+        utilities::read_limit(STDIN.lock().await.deref_mut(), f64::from(limit) as usize)
             .await
             .into(),
     )
@@ -18,10 +27,18 @@ async fn _pen_os_read_limit_stdin(limit: ffi::Number) -> ffi::Arc<FfiResult<ffi:
 
 #[ffi::bindgen]
 async fn _pen_os_write_stdout(bytes: ffi::ByteString) -> ffi::Arc<FfiResult<ffi::Number>> {
-    ffi::Arc::new(utilities::write(&mut stdout(), bytes).await.into())
+    ffi::Arc::new(
+        utilities::write(STDOUT.lock().await.deref_mut(), bytes)
+            .await
+            .into(),
+    )
 }
 
 #[ffi::bindgen]
 async fn _pen_os_write_stderr(bytes: ffi::ByteString) -> ffi::Arc<FfiResult<ffi::Number>> {
-    ffi::Arc::new(utilities::write(&mut stderr(), bytes).await.into())
+    ffi::Arc::new(
+        utilities::write(STDERR.lock().await.deref_mut(), bytes)
+            .await
+            .into(),
+    )
 }


### PR DESCRIPTION
But `Stdout` and etc. all implement `Sync` and `Send`. Is there any more performant way?