### PR TITLE
Thunk lock handling

### DIFF
--- a/cmd/test/src/spawn.rs
+++ b/cmd/test/src/spawn.rs
@@ -1,4 +1,9 @@
-#[no_mangle]
-extern "C" fn _pen_spawn(closure: ffi::Arc<ffi::Closure>) -> ffi::Arc<ffi::Closure> {
+#[ffi::bindgen]
+fn _pen_spawn(closure: ffi::Arc<ffi::Closure>) -> ffi::Arc<ffi::Closure> {
     closure
+}
+
+#[ffi::bindgen]
+async fn _pen_yield() -> ffi::None {
+    unreachable!("thunk lock detected")
 }

--- a/lib/mir-fmm/src/entry_functions.rs
+++ b/lib/mir-fmm/src/entry_functions.rs
@@ -129,7 +129,6 @@ fn compile_initial_thunk_entry(
     types: &FnvHashMap<String, mir::types::RecordBody>,
 ) -> Result<fmm::build::TypedExpression, CompileError> {
     let entry_function_name = module_builder.generate_name();
-    let entry_function_type = types::compile_entry_function(definition.type_(), types);
     let arguments = compile_arguments(definition, types);
 
     module_builder.define_function(
@@ -141,7 +140,10 @@ fn compile_initial_thunk_entry(
             instruction_builder.if_(
                 instruction_builder.compare_and_swap(
                     entry_function_pointer.clone(),
-                    fmm::build::variable(&entry_function_name, entry_function_type.clone()),
+                    fmm::build::variable(
+                        &entry_function_name,
+                        types::compile_entry_function(definition.type_(), types),
+                    ),
                     lock_entry_function.clone(),
                     fmm::ir::AtomicOrdering::Acquire,
                     fmm::ir::AtomicOrdering::Relaxed,

--- a/lib/mir-fmm/src/entry_functions.rs
+++ b/lib/mir-fmm/src/entry_functions.rs
@@ -1,6 +1,8 @@
 use super::error::CompileError;
-use crate::yield_::{YIELD_FUNCTION_NAME, YIELD_FUNCTION_TYPE};
-use crate::{closures, expressions, reference_count, types};
+use crate::{
+    closures, expressions, reference_count, types,
+    yield_::{YIELD_FUNCTION_NAME, YIELD_FUNCTION_TYPE},
+};
 use fnv::FnvHashMap;
 
 const CLOSURE_NAME: &str = "_closure";

--- a/lib/mir-fmm/src/entry_functions.rs
+++ b/lib/mir-fmm/src/entry_functions.rs
@@ -1,10 +1,9 @@
 use super::error::CompileError;
+use crate::yield_::{YIELD_FUNCTION_NAME, YIELD_FUNCTION_TYPE};
 use crate::{closures, expressions, reference_count, types};
 use fnv::FnvHashMap;
 
 const CLOSURE_NAME: &str = "_closure";
-// TODO Inject this as a configuration.
-const YIELD_FUNCTION_NAME: &str = "_pen_yield";
 
 pub fn compile(
     module_builder: &fmm::build::ModuleBuilder,
@@ -281,14 +280,7 @@ fn compile_locked_thunk_entry(
                 )?,
                 |instruction_builder| {
                     instruction_builder.call(
-                        fmm::build::variable(
-                            YIELD_FUNCTION_NAME,
-                            fmm::types::Function::new(
-                                vec![],
-                                fmm::types::VOID_TYPE.clone(),
-                                fmm::types::CallingConvention::Source,
-                            ),
-                        ),
+                        fmm::build::variable(YIELD_FUNCTION_NAME, YIELD_FUNCTION_TYPE.clone()),
                         vec![],
                     )?;
 

--- a/lib/mir-fmm/src/lib.rs
+++ b/lib/mir-fmm/src/lib.rs
@@ -21,7 +21,7 @@ use fnv::FnvHashMap;
 use foreign_declarations::compile_foreign_declaration;
 use foreign_definitions::compile_foreign_definition;
 use type_information::compile_type_information_global_variable;
-use yield_::{YIELD_FUNCTION_NAME, YIELD_FUNCTION_TYPE};
+use yield_::compile_yield_function_declaration;
 
 pub fn compile(module: &mir::ir::Module) -> Result<fmm::ir::Module, CompileError> {
     mir::analysis::check_types(module)?;
@@ -92,10 +92,6 @@ pub fn compile(module: &mir::ir::Module) -> Result<fmm::ir::Module, CompileError
     compile_yield_function_declaration(&module_builder);
 
     Ok(module_builder.as_module())
-}
-
-fn compile_yield_function_declaration(module_builder: &fmm::build::ModuleBuilder) {
-    module_builder.declare_function(YIELD_FUNCTION_NAME, YIELD_FUNCTION_TYPE.clone());
 }
 
 fn compile_global_variables(

--- a/lib/mir-fmm/src/lib.rs
+++ b/lib/mir-fmm/src/lib.rs
@@ -12,6 +12,7 @@ mod reference_count;
 mod type_information;
 mod types;
 mod variants;
+mod yield_;
 
 use declarations::compile_declaration;
 use definitions::compile_definition;
@@ -20,6 +21,7 @@ use fnv::FnvHashMap;
 use foreign_declarations::compile_foreign_declaration;
 use foreign_definitions::compile_foreign_definition;
 use type_information::compile_type_information_global_variable;
+use yield_::{YIELD_FUNCTION_NAME, YIELD_FUNCTION_TYPE};
 
 pub fn compile(module: &mir::ir::Module) -> Result<fmm::ir::Module, CompileError> {
     mir::analysis::check_types(module)?;
@@ -87,7 +89,13 @@ pub fn compile(module: &mir::ir::Module) -> Result<fmm::ir::Module, CompileError
         )?;
     }
 
+    compile_yield_function_declaration(&module_builder);
+
     Ok(module_builder.as_module())
+}
+
+fn compile_yield_function_declaration(module_builder: &fmm::build::ModuleBuilder) {
+    module_builder.declare_function(YIELD_FUNCTION_NAME, YIELD_FUNCTION_TYPE.clone());
 }
 
 fn compile_global_variables(

--- a/lib/mir-fmm/src/yield_.rs
+++ b/lib/mir-fmm/src/yield_.rs
@@ -1,0 +1,12 @@
+use once_cell::sync::Lazy;
+
+// TODO Inject this as a configuration.
+pub const YIELD_FUNCTION_NAME: &str = "_pen_yield";
+
+pub static YIELD_FUNCTION_TYPE: Lazy<fmm::types::Function> = Lazy::new(|| {
+    fmm::types::Function::new(
+        vec![],
+        fmm::types::VOID_TYPE.clone(),
+        fmm::types::CallingConvention::Source,
+    )
+});

--- a/lib/mir-fmm/src/yield_.rs
+++ b/lib/mir-fmm/src/yield_.rs
@@ -10,3 +10,7 @@ pub static YIELD_FUNCTION_TYPE: Lazy<fmm::types::Function> = Lazy::new(|| {
         fmm::types::CallingConvention::Source,
     )
 });
+
+pub fn compile_yield_function_declaration(module_builder: &fmm::build::ModuleBuilder) {
+    module_builder.declare_function(YIELD_FUNCTION_NAME, YIELD_FUNCTION_TYPE.clone());
+}

--- a/lib/os-sync/ffi/application/src/concurrency.rs
+++ b/lib/os-sync/ffi/application/src/concurrency.rs
@@ -2,3 +2,8 @@
 fn _pen_spawn(closure: ffi::Arc<ffi::Closure>) -> ffi::Arc<ffi::Closure> {
     closure
 }
+
+#[ffi::bindgen]
+async fn _pen_yield() {
+    unreachable!("thunk lock detected")
+}

--- a/lib/os-sync/ffi/application/src/concurrency.rs
+++ b/lib/os-sync/ffi/application/src/concurrency.rs
@@ -4,6 +4,6 @@ fn _pen_spawn(closure: ffi::Arc<ffi::Closure>) -> ffi::Arc<ffi::Closure> {
 }
 
 #[ffi::bindgen]
-async fn _pen_yield() {
+async fn _pen_yield() -> ffi::None {
     unreachable!("thunk lock detected")
 }

--- a/lib/os/ffi/application/src/concurrency.rs
+++ b/lib/os/ffi/application/src/concurrency.rs
@@ -1,5 +1,5 @@
 use std::future::Future;
-use tokio::spawn;
+use tokio::{spawn, task::yield_now};
 
 #[ffi::bindgen]
 fn _pen_spawn(closure: ffi::Arc<ffi::Closure>) -> ffi::Arc<ffi::Closure> {
@@ -8,4 +8,9 @@ fn _pen_spawn(closure: ffi::Arc<ffi::Closure>) -> ffi::Arc<ffi::Closure> {
 
 async fn spawn_and_unwrap(future: impl Future<Output = ffi::Any> + Send + 'static) -> ffi::Any {
     spawn(future).await.unwrap()
+}
+
+#[ffi::bindgen]
+async fn _pen_yield() {
+    yield_now().await;
 }


### PR DESCRIPTION
Close #648.

As described in #648, we might want to implement some other methods like blackholing eventually in the future. But we implement the most naive method of yielding from green threads cooperatively for simplicity in this PR.
