### PR TITLE
Simple small record boxing strategy

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -46,6 +46,7 @@
     "println",
     "raviqqe",
     "realloc",
+    "recursivity",
     "renamer",
     "repr",
     "rfind",

--- a/lib/mir-fmm/src/error.rs
+++ b/lib/mir-fmm/src/error.rs
@@ -10,6 +10,7 @@ pub enum CompileError {
     NestedVariant,
     ReferenceCount(mir::analysis::ReferenceCountError),
     TypeCheck(mir::analysis::TypeCheckError),
+    UnboxedRecord,
 }
 
 impl Display for CompileError {

--- a/lib/mir-fmm/src/foreign_declaration.rs
+++ b/lib/mir-fmm/src/foreign_declaration.rs
@@ -62,7 +62,7 @@ fn compile_entry_function(
                                 declaration.type_(),
                                 declaration.calling_convention(),
                                 context.types(),
-                            ),
+                            )?,
                         ),
                         arguments[FUNCTION_ARGUMENT_OFFSET..]
                             .iter()

--- a/lib/mir-fmm/src/foreign_definition.rs
+++ b/lib/mir-fmm/src/foreign_definition.rs
@@ -10,7 +10,7 @@ pub fn compile_foreign_definition(
         function_type,
         definition.calling_convention(),
         context.types(),
-    );
+    )?;
     let arguments = foreign_function_type
         .arguments()
         .iter()

--- a/lib/mir-fmm/src/foreign_value.rs
+++ b/lib/mir-fmm/src/foreign_value.rs
@@ -9,7 +9,7 @@ pub fn convert_to_foreign(
 ) -> Result<fmm::build::TypedExpression, CompileError> {
     let value = value.into();
 
-    Ok(if type_::foreign::should_box_payload(type_, types) {
+    Ok(if type_::foreign::should_box_payload(type_, types)? {
         box_::box_(builder, value)?
     } else {
         value
@@ -24,7 +24,7 @@ pub fn convert_from_foreign(
 ) -> Result<fmm::build::TypedExpression, CompileError> {
     let value = value.into();
 
-    Ok(if type_::foreign::should_box_payload(type_, types) {
+    Ok(if type_::foreign::should_box_payload(type_, types)? {
         box_::unbox(builder, value, type_, types)?
     } else {
         value

--- a/lib/mir-fmm/src/reference_count/record_utilities.rs
+++ b/lib/mir-fmm/src/reference_count/record_utilities.rs
@@ -2,15 +2,15 @@ use super::super::type_;
 use fnv::FnvHashMap;
 
 pub fn get_record_clone_function_name(name: &str) -> String {
-    format!("mir_clone_{}", name)
+    format!("mir_clone:{}", name)
 }
 
 pub fn get_record_drop_function_name(name: &str) -> String {
-    format!("mir_drop_{}", name)
+    format!("mir_drop:{}", name)
 }
 
 pub fn get_record_drop_or_reuse_function_name(name: &str) -> String {
-    format!("mir_drop_or_reuse_{}", name)
+    format!("mir_drop_or_reuse:{}", name)
 }
 
 pub fn compile_record_clone_function_type(

--- a/lib/mir-fmm/src/type_.rs
+++ b/lib/mir-fmm/src/type_.rs
@@ -81,12 +81,17 @@ pub fn compile_record(
     }
 }
 
-// TODO
 pub fn is_record_boxed(
     record: &mir::types::Record,
     types: &FnvHashMap<String, mir::types::RecordBody>,
 ) -> bool {
-    !types[record.name()].fields().is_empty()
+    let body_type = &types[record.name()];
+
+    body_type.fields().len() > 2
+        || body_type
+            .fields()
+            .iter()
+            .any(|type_| matches!(type_, mir::types::Type::Record(_)))
 }
 
 pub fn compile_boxed_record() -> fmm::types::Type {

--- a/lib/mir-fmm/src/type_.rs
+++ b/lib/mir-fmm/src/type_.rs
@@ -87,7 +87,7 @@ pub fn is_record_boxed(
 ) -> bool {
     let body_type = &types[record.name()];
 
-    body_type.fields().len() > 2
+    body_type.fields().len() > 1
         || body_type
             .fields()
             .iter()

--- a/lib/mir-fmm/src/type_.rs
+++ b/lib/mir-fmm/src/type_.rs
@@ -87,6 +87,9 @@ pub fn is_record_boxed(
 ) -> bool {
     let body_type = &types[record.name()];
 
+    // Unbox small records.
+    // TODO Try unboxing 2-field records.
+    // TODO Check recursivity.
     body_type.fields().len() > 1
         || body_type
             .fields()

--- a/lib/mir-fmm/src/type_.rs
+++ b/lib/mir-fmm/src/type_.rs
@@ -87,14 +87,8 @@ pub fn is_record_boxed(
 ) -> bool {
     let body_type = &types[record.name()];
 
-    // Unbox small records.
-    // TODO Try unboxing 2-field records.
-    // TODO Check recursivity.
-    body_type.fields().len() > 1
-        || body_type
-            .fields()
-            .iter()
-            .any(|type_| matches!(type_, mir::types::Type::Record(_)))
+    // TODO
+    !body_type.fields().is_empty()
 }
 
 pub fn compile_boxed_record() -> fmm::types::Type {

--- a/lib/mir-fmm/src/type_.rs
+++ b/lib/mir-fmm/src/type_.rs
@@ -91,12 +91,10 @@ pub fn is_record_boxed(
     // TODO Try unboxing 2-field records.
     // TODO Check recursivity.
     body_type.fields().len() > 1
-        || body_type.fields().iter().any(|type_| {
-            matches!(
-                type_,
-                mir::types::Type::Record(_) | mir::types::Type::Variant
-            )
-        })
+        || body_type
+            .fields()
+            .iter()
+            .any(|type_| matches!(type_, mir::types::Type::Record(_)))
 }
 
 pub fn compile_boxed_record() -> fmm::types::Type {

--- a/lib/mir-fmm/src/type_.rs
+++ b/lib/mir-fmm/src/type_.rs
@@ -91,10 +91,12 @@ pub fn is_record_boxed(
     // TODO Try unboxing 2-field records.
     // TODO Check recursivity.
     body_type.fields().len() > 1
-        || body_type
-            .fields()
-            .iter()
-            .any(|type_| matches!(type_, mir::types::Type::Record(_)))
+        || body_type.fields().iter().any(|type_| {
+            matches!(
+                type_,
+                mir::types::Type::Record(_) | mir::types::Type::Variant
+            )
+        })
 }
 
 pub fn compile_boxed_record() -> fmm::types::Type {

--- a/lib/mir-fmm/src/type_/foreign.rs
+++ b/lib/mir-fmm/src/type_/foreign.rs
@@ -1,41 +1,45 @@
-use crate::type_;
+use crate::{type_, CompileError};
 use fnv::FnvHashMap;
 
 pub fn compile(
     type_: &mir::types::Type,
     types: &FnvHashMap<String, mir::types::RecordBody>,
-) -> fmm::types::Type {
+) -> Result<fmm::types::Type, CompileError> {
     let fmm_type = type_::compile(type_, types);
 
-    if should_box_payload(type_, types) {
+    Ok(if should_box_payload(type_, types)? {
         fmm::types::Pointer::new(fmm_type).into()
     } else {
         fmm_type
-    }
+    })
 }
 
 pub fn compile_function(
     function: &mir::types::Function,
     calling_convention: mir::ir::CallingConvention,
     types: &FnvHashMap<String, mir::types::RecordBody>,
-) -> fmm::types::Function {
-    fmm::types::Function::new(
+) -> Result<fmm::types::Function, CompileError> {
+    Ok(fmm::types::Function::new(
         function
             .arguments()
             .iter()
             .map(|type_| compile(type_, types))
-            .collect(),
-        compile(function.result(), types),
+            .collect::<Result<_, _>>()?,
+        compile(function.result(), types)?,
         type_::compile_calling_convention(calling_convention),
-    )
+    ))
 }
 
 pub fn should_box_payload(
     type_: &mir::types::Type,
     types: &FnvHashMap<String, mir::types::RecordBody>,
-) -> bool {
-    match type_ {
+) -> Result<bool, CompileError> {
+    Ok(match type_ {
         mir::types::Type::Record(record_type) => {
+            if type_::is_record_boxed(record_type, types) && !is_record_boxed(record_type, types) {
+                return Err(CompileError::UnboxedRecord);
+            }
+
             type_::is_record_boxed(record_type, types) != is_record_boxed(record_type, types)
         }
         mir::types::Type::Variant => true,
@@ -44,7 +48,7 @@ pub fn should_box_payload(
         | mir::types::Type::Function(_)
         | mir::types::Type::None
         | mir::types::Type::Number => false,
-    }
+    })
 }
 
 fn is_record_boxed(

--- a/lib/mir-fmm/src/type_/variant.rs
+++ b/lib/mir-fmm/src/type_/variant.rs
@@ -31,6 +31,7 @@ pub fn should_box_payload(
     })
 }
 
+// Box records to stuff them into one word.
 fn is_record_boxed(
     record: &mir::types::Record,
     types: &FnvHashMap<String, mir::types::RecordBody>,

--- a/lib/mir-fmm/src/type_/variant.rs
+++ b/lib/mir-fmm/src/type_/variant.rs
@@ -42,12 +42,6 @@ fn is_record_boxed(
 ) -> bool {
     let body_type = &types[record.name()];
 
-    body_type.fields().len() > 1
-        || body_type.fields().iter().any(|type_| {
-            // Variants always take two words.
-            matches!(
-                type_,
-                mir::types::Type::Record(_) | mir::types::Type::Variant
-            )
-        })
+    // TODO
+    !body_type.fields().is_empty()
 }

--- a/lib/mir-fmm/src/type_/variant.rs
+++ b/lib/mir-fmm/src/type_/variant.rs
@@ -31,10 +31,18 @@ pub fn should_box_payload(
     })
 }
 
-// TODO
 fn is_record_boxed(
     record: &mir::types::Record,
     types: &FnvHashMap<String, mir::types::RecordBody>,
 ) -> bool {
-    !types[record.name()].fields().is_empty()
+    let body_type = &types[record.name()];
+
+    body_type.fields().len() > 1
+        || body_type.fields().iter().any(|type_| {
+            // Variants always take two words.
+            matches!(
+                type_,
+                mir::types::Type::Record(_) | mir::types::Type::Variant
+            )
+        })
 }

--- a/lib/mir-fmm/src/type_/variant.rs
+++ b/lib/mir-fmm/src/type_/variant.rs
@@ -20,6 +20,10 @@ pub fn should_box_payload(
 ) -> Result<bool, CompileError> {
     Ok(match type_ {
         mir::types::Type::Record(record_type) => {
+            if type_::is_record_boxed(record_type, types) && !is_record_boxed(record_type, types) {
+                return Err(CompileError::UnboxedRecord);
+            }
+
             type_::is_record_boxed(record_type, types) != is_record_boxed(record_type, types)
         }
         mir::types::Type::Variant => return Err(CompileError::NestedVariant),


### PR DESCRIPTION
Actual implementation of unboxing is postponed due to a bug of nested foreign records.

- https://github.com/pen-lang/pen/pull/1033/commits/1bbd8d2302e6418fa373afec9a6214a082aab896

# Todo

- [x] Return errors on unboxing boxed records for variants and FFI.

# Experiments

## Life game

- Iterations:
  - `time`: 1000
  - `valgrind`: 10

### Before

```
> time ./app
./app  16.25s user 0.15s system 100% cpu 16.387 total
```

```
> valgrind ./app
==158695==
==158695== HEAP SUMMARY:
==158695==     in use at exit: 13,316 bytes in 78 blocks
==158695==   total heap usage: 2,090,777 allocs, 2,090,699 frees, 57,136,247 bytes allocated
==158695==
==158695== LEAK SUMMARY:
==158695==    definitely lost: 0 bytes in 0 blocks
==158695==    indirectly lost: 0 bytes in 0 blocks
==158695==      possibly lost: 328 bytes in 4 blocks
==158695==    still reachable: 12,988 bytes in 74 blocks
==158695==                       of which reachable via heuristic:
==158695==                         newarray           : 16 bytes in 1 blocks
==158695==         suppressed: 0 bytes in 0 blocks
==158695== Rerun with --leak-check=full to see details of leaked memory
==158695==
==158695== For lists of detected and suppressed errors, rerun with: -s
==158695== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

### After 

```
> time ./app
./app  15.00s user 0.13s system 99% cpu 15.133 total
```

```
> valgrind ./app
==166028==
==166028== HEAP SUMMARY:
==166028==     in use at exit: 13,276 bytes in 76 blocks
==166028==   total heap usage: 1,591,202 allocs, 1,591,126 frees, 53,090,455 bytes allocated
==166028==
==166028== LEAK SUMMARY:
==166028==    definitely lost: 0 bytes in 0 blocks
==166028==    indirectly lost: 0 bytes in 0 blocks
==166028==      possibly lost: 288 bytes in 2 blocks
==166028==    still reachable: 12,988 bytes in 74 blocks
==166028==                       of which reachable via heuristic:
==166028==                         newarray           : 16 bytes in 1 blocks
==166028==         suppressed: 0 bytes in 0 blocks
==166028== Rerun with --leak-check=full to see details of leaked memory
==166028==
==166028== For lists of detected and suppressed errors, rerun with: -s
==166028== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```