### PR TITLE
Static counts in reference counting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -996,7 +996,7 @@ dependencies = [
 
 [[package]]
 name = "pen-ffi"
-version = "0.6.7"
+version = "0.7.0"
 dependencies = [
  "async-stream",
  "futures",

--- a/cmd/test/Cargo.lock
+++ b/cmd/test/Cargo.lock
@@ -126,9 +126,9 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "pen-ffi"
-version = "0.6.5"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe1c76f2b4750111704f5be6d43274918e1cfbbb164dc4d700f5fc23646a685"
+checksum = "2ea360568d5fab450011e7d61d5cf2b294a8b560b87b5c19d5ad1a343aa25f9d"
 dependencies = [
  "async-stream",
  "futures",

--- a/lib/ffi/Cargo.toml
+++ b/lib/ffi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pen-ffi"
 description = "FFI library for Pen programming language"
-version = "0.6.7"
+version = "0.7.0"
 publish = true
 edition = "2021"
 license = "MIT"

--- a/lib/ffi/src/arc/arc_block.rs
+++ b/lib/ffi/src/arc/arc_block.rs
@@ -5,6 +5,8 @@ use core::{
     sync::atomic::{fence, AtomicIsize, Ordering},
 };
 
+// TODO Implement sticky count ranges.
+
 const UNIQUE_COUNT: isize = 0;
 const SYNCHRONIZED_UNIQUE_COUNT: isize = -1;
 

--- a/lib/ffi/src/arc/arc_block.rs
+++ b/lib/ffi/src/arc/arc_block.rs
@@ -1,7 +1,6 @@
 use alloc::alloc::{alloc, dealloc};
 use core::{
     alloc::Layout,
-    mem::size_of,
     ptr::{drop_in_place, null},
     sync::atomic::{fence, AtomicIsize, Ordering},
 };
@@ -9,7 +8,7 @@ use core::{
 const UNIQUE_COUNT: isize = 0;
 const SYNCHRONIZED_UNIQUE_COUNT: isize = -1;
 // The static count is also synchronized.
-const STATIC_COUNT: isize = 1 << (size_of::<isize>() * 8 - 1);
+const STATIC_COUNT: isize = 1 << (isize::BITS as usize - 1);
 
 #[derive(Debug)]
 #[repr(C)]

--- a/lib/ffi/src/arc/arc_block.rs
+++ b/lib/ffi/src/arc/arc_block.rs
@@ -6,8 +6,6 @@ use core::{
     sync::atomic::{fence, AtomicIsize, Ordering},
 };
 
-// TODO Implement sticky count ranges.
-
 const UNIQUE_COUNT: isize = 0;
 const SYNCHRONIZED_UNIQUE_COUNT: isize = -1;
 // The static count is also synchronized.

--- a/lib/ffi/src/arc/arc_buffer.rs
+++ b/lib/ffi/src/arc/arc_buffer.rs
@@ -107,11 +107,6 @@ mod tests {
     }
 
     #[test]
-    fn create_zero_sized_buffer() {
-        ArcBuffer::new(0);
-    }
-
-    #[test]
     fn clone() {
         let arc = ArcBuffer::new(42);
         drop(arc.clone());

--- a/lib/infra/src/ninja_build_script_compiler.rs
+++ b/lib/infra/src/ninja_build_script_compiler.rs
@@ -92,7 +92,7 @@ impl NinjaBuildScriptCompiler {
             &format!(
                 "  command = {} \
                     -function-attrs -adce -globalopt -gvn -inline \
-                    -aggressive-instcombine -adce -mergefunc \
+                    -aggressive-instcombine -adce -mergefunc -tailcallelim \
                     -o $out $in",
                 opt.display(),
             ),

--- a/lib/mir-fmm/src/closure.rs
+++ b/lib/mir-fmm/src/closure.rs
@@ -2,7 +2,7 @@ mod drop;
 pub mod metadata;
 mod sync;
 
-use super::{reference_count, CompileError};
+use super::CompileError;
 
 pub fn get_entry_function_pointer(
     closure_pointer: impl Into<fmm::build::TypedExpression>,
@@ -26,11 +26,7 @@ fn get_field(
     closure_pointer: impl Into<fmm::build::TypedExpression>,
     index: usize,
 ) -> Result<fmm::build::TypedExpression, CompileError> {
-    Ok(fmm::build::record_address(
-        reference_count::pointer::untag(&closure_pointer.into())?,
-        index,
-    )?
-    .into())
+    Ok(fmm::build::record_address(closure_pointer, index)?.into())
 }
 
 pub fn compile_content(

--- a/lib/mir-fmm/src/expression.rs
+++ b/lib/mir-fmm/src/expression.rs
@@ -201,24 +201,20 @@ pub fn compile(
                     type_::compile_string(),
                     fmm::build::record_address(
                         context.module_builder().define_anonymous_variable(
-                            fmm::build::record(vec![
-                                reference_count::count::compile_static()?.into(),
-                                fmm::build::record(
-                                    [fmm::ir::Primitive::PointerInteger(
-                                        string.value().len() as i64
-                                    )
-                                    .into()]
-                                    .into_iter()
-                                    .chain(
-                                        string
-                                            .value()
-                                            .iter()
-                                            .map(|&byte| fmm::ir::Primitive::Integer8(byte).into()),
-                                    )
-                                    .collect(),
+                            reference_count::compile_static(fmm::build::record(
+                                [
+                                    fmm::ir::Primitive::PointerInteger(string.value().len() as i64)
+                                        .into(),
+                                ]
+                                .into_iter()
+                                .chain(
+                                    string
+                                        .value()
+                                        .iter()
+                                        .map(|&byte| fmm::ir::Primitive::Integer8(byte).into()),
                                 )
-                                .into(),
-                            ]),
+                                .collect(),
+                            ))?,
                             false,
                             None,
                         ),

--- a/lib/mir-fmm/src/expression.rs
+++ b/lib/mir-fmm/src/expression.rs
@@ -197,30 +197,35 @@ pub fn compile(
             if string.value().is_empty() {
                 fmm::ir::Undefined::new(type_::compile_string()).into()
             } else {
-                reference_count::pointer::tag_as_static(
-                    &fmm::build::bit_cast(
-                        type_::compile_string(),
+                fmm::build::bit_cast(
+                    type_::compile_string(),
+                    fmm::build::record_address(
                         context.module_builder().define_anonymous_variable(
-                            fmm::build::record(
-                                [
-                                    fmm::ir::Primitive::PointerInteger(string.value().len() as i64)
-                                        .into(),
-                                ]
-                                .into_iter()
-                                .chain(
-                                    string
-                                        .value()
-                                        .iter()
-                                        .map(|&byte| fmm::ir::Primitive::Integer8(byte).into()),
+                            fmm::build::record(vec![
+                                reference_count::count::compile_static()?.into(),
+                                fmm::build::record(
+                                    [fmm::ir::Primitive::PointerInteger(
+                                        string.value().len() as i64
+                                    )
+                                    .into()]
+                                    .into_iter()
+                                    .chain(
+                                        string
+                                            .value()
+                                            .iter()
+                                            .map(|&byte| fmm::ir::Primitive::Integer8(byte).into()),
+                                    )
+                                    .collect(),
                                 )
-                                .collect(),
-                            ),
+                                .into(),
+                            ]),
                             false,
                             None,
                         ),
-                    )
-                    .into(),
-                )?
+                        1,
+                    )?,
+                )
+                .into()
             }
         }
         mir::ir::Expression::TryOperation(operation) => {

--- a/lib/mir-fmm/src/expression.rs
+++ b/lib/mir-fmm/src/expression.rs
@@ -201,7 +201,7 @@ pub fn compile(
                     type_::compile_string(),
                     fmm::build::record_address(
                         context.module_builder().define_anonymous_variable(
-                            reference_count::compile_static(fmm::build::record(
+                            reference_count::block::compile_static(fmm::build::record(
                                 [
                                     fmm::ir::Primitive::PointerInteger(string.value().len() as i64)
                                         .into(),

--- a/lib/mir-fmm/src/foreign_declaration.rs
+++ b/lib/mir-fmm/src/foreign_declaration.rs
@@ -12,7 +12,7 @@ pub fn compile(
 ) -> Result<(), CompileError> {
     context.module_builder().define_variable(
         declaration.name(),
-        reference_count::compile_static(closure::compile_content(
+        reference_count::block::compile_static(closure::compile_content(
             compile_entry_function(context, declaration)?,
             fmm::ir::Undefined::new(type_::compile_closure_metadata()),
             fmm::build::record(vec![]),

--- a/lib/mir-fmm/src/foreign_declaration.rs
+++ b/lib/mir-fmm/src/foreign_declaration.rs
@@ -12,14 +12,11 @@ pub fn compile(
 ) -> Result<(), CompileError> {
     context.module_builder().define_variable(
         declaration.name(),
-        fmm::build::record(vec![
-            reference_count::count::compile_static()?,
-            closure::compile_content(
-                compile_entry_function(context, declaration)?,
-                fmm::ir::Undefined::new(type_::compile_closure_metadata()),
-                fmm::build::record(vec![]),
-            ),
-        ]),
+        reference_count::compile_static(closure::compile_content(
+            compile_entry_function(context, declaration)?,
+            fmm::ir::Undefined::new(type_::compile_closure_metadata()),
+            fmm::build::record(vec![]),
+        ))?,
         false,
         fmm::ir::Linkage::Internal,
         None,

--- a/lib/mir-fmm/src/foreign_declaration.rs
+++ b/lib/mir-fmm/src/foreign_declaration.rs
@@ -1,7 +1,7 @@
 use crate::{
     closure,
     context::Context,
-    foreign_value,
+    foreign_value, reference_count,
     type_::{self, FUNCTION_ARGUMENT_OFFSET},
     CompileError,
 };
@@ -12,11 +12,14 @@ pub fn compile(
 ) -> Result<(), CompileError> {
     context.module_builder().define_variable(
         declaration.name(),
-        closure::compile_content(
-            compile_entry_function(context, declaration)?,
-            fmm::ir::Undefined::new(type_::compile_closure_metadata()),
-            fmm::build::record(vec![]),
-        ),
+        fmm::build::record(vec![
+            reference_count::count::compile_static()?,
+            closure::compile_content(
+                compile_entry_function(context, declaration)?,
+                fmm::ir::Undefined::new(type_::compile_closure_metadata()),
+                fmm::build::record(vec![]),
+            ),
+        ]),
         false,
         fmm::ir::Linkage::Internal,
         None,

--- a/lib/mir-fmm/src/function_declaration.rs
+++ b/lib/mir-fmm/src/function_declaration.rs
@@ -3,7 +3,7 @@ use crate::{context::Context, reference_count, type_};
 pub fn compile(context: &Context, declaration: &mir::ir::FunctionDeclaration) {
     context.module_builder().declare_variable(
         declaration.name(),
-        reference_count::heap::compile_type_with_reference_count(type_::compile_unsized_closure(
+        reference_count::compile_type_with_reference_count(type_::compile_unsized_closure(
             declaration.type_(),
             context.types(),
         )),

--- a/lib/mir-fmm/src/function_declaration.rs
+++ b/lib/mir-fmm/src/function_declaration.rs
@@ -3,7 +3,7 @@ use crate::{context::Context, reference_count, type_};
 pub fn compile(context: &Context, declaration: &mir::ir::FunctionDeclaration) {
     context.module_builder().declare_variable(
         declaration.name(),
-        reference_count::compile_type_with_reference_count(type_::compile_unsized_closure(
+        reference_count::block::compile_type(type_::compile_unsized_closure(
             declaration.type_(),
             context.types(),
         )),

--- a/lib/mir-fmm/src/function_declaration.rs
+++ b/lib/mir-fmm/src/function_declaration.rs
@@ -1,5 +1,4 @@
-use crate::context::Context;
-use crate::{reference_count, type_};
+use crate::{context::Context, reference_count, type_};
 
 pub fn compile(context: &Context, declaration: &mir::ir::FunctionDeclaration) {
     context.module_builder().declare_variable(

--- a/lib/mir-fmm/src/function_declaration.rs
+++ b/lib/mir-fmm/src/function_declaration.rs
@@ -1,9 +1,12 @@
-use super::type_;
 use crate::context::Context;
+use crate::{reference_count, type_};
 
 pub fn compile(context: &Context, declaration: &mir::ir::FunctionDeclaration) {
     context.module_builder().declare_variable(
         declaration.name(),
-        type_::compile_unsized_closure(declaration.type_(), context.types()),
+        reference_count::heap::compile_type_with_reference_count(type_::compile_unsized_closure(
+            declaration.type_(),
+            context.types(),
+        )),
     );
 }

--- a/lib/mir-fmm/src/function_definition.rs
+++ b/lib/mir-fmm/src/function_definition.rs
@@ -10,17 +10,11 @@ pub fn compile(
 ) -> Result<(), CompileError> {
     context.module_builder().define_variable(
         definition.name(),
-        fmm::build::record(vec![
-            reference_count::count::compile_static()?,
-            closure::compile_content(
-                entry_function::compile(context, definition, true, global_variables)?,
-                closure::metadata::compile(context, definition)?,
-                fmm::ir::Undefined::new(type_::compile_closure_payload(
-                    definition,
-                    context.types(),
-                )),
-            ),
-        ]),
+        reference_count::compile_static(closure::compile_content(
+            entry_function::compile(context, definition, true, global_variables)?,
+            closure::metadata::compile(context, definition)?,
+            fmm::ir::Undefined::new(type_::compile_closure_payload(definition, context.types())),
+        ))?,
         definition.is_thunk(),
         fmm::ir::Linkage::External,
         None,

--- a/lib/mir-fmm/src/function_definition.rs
+++ b/lib/mir-fmm/src/function_definition.rs
@@ -1,5 +1,6 @@
-use super::error::CompileError;
-use crate::{closure, context::Context, entry_function, type_};
+use crate::{
+    closure, context::Context, entry_function, error::CompileError, reference_count, type_,
+};
 use fnv::FnvHashMap;
 
 pub fn compile(
@@ -9,11 +10,17 @@ pub fn compile(
 ) -> Result<(), CompileError> {
     context.module_builder().define_variable(
         definition.name(),
-        closure::compile_content(
-            entry_function::compile(context, definition, true, global_variables)?,
-            closure::metadata::compile(context, definition)?,
-            fmm::ir::Undefined::new(type_::compile_closure_payload(definition, context.types())),
-        ),
+        fmm::build::record(vec![
+            reference_count::count::compile_static()?,
+            closure::compile_content(
+                entry_function::compile(context, definition, true, global_variables)?,
+                closure::metadata::compile(context, definition)?,
+                fmm::ir::Undefined::new(type_::compile_closure_payload(
+                    definition,
+                    context.types(),
+                )),
+            ),
+        ]),
         definition.is_thunk(),
         fmm::ir::Linkage::External,
         None,

--- a/lib/mir-fmm/src/function_definition.rs
+++ b/lib/mir-fmm/src/function_definition.rs
@@ -10,7 +10,7 @@ pub fn compile(
 ) -> Result<(), CompileError> {
     context.module_builder().define_variable(
         definition.name(),
-        reference_count::compile_static(closure::compile_content(
+        reference_count::block::compile_static(closure::compile_content(
             entry_function::compile(context, definition, true, global_variables)?,
             closure::metadata::compile(context, definition)?,
             fmm::ir::Undefined::new(type_::compile_closure_payload(definition, context.types())),

--- a/lib/mir-fmm/src/lib.rs
+++ b/lib/mir-fmm/src/lib.rs
@@ -105,11 +105,9 @@ fn compile_global_variables(
                 declaration.name().into(),
                 fmm::build::variable(
                     declaration.name(),
-                    fmm::types::Pointer::new(
-                        reference_count::heap::compile_type_with_reference_count(
-                            type_::compile_unsized_closure(declaration.type_(), types),
-                        ),
-                    ),
+                    fmm::types::Pointer::new(reference_count::compile_type_with_reference_count(
+                        type_::compile_unsized_closure(declaration.type_(), types),
+                    )),
                 ),
             )
         })
@@ -118,11 +116,9 @@ fn compile_global_variables(
                 declaration.name().into(),
                 fmm::build::variable(
                     declaration.name(),
-                    fmm::types::Pointer::new(
-                        reference_count::heap::compile_type_with_reference_count(
-                            type_::compile_unsized_closure(declaration.type_(), types),
-                        ),
-                    ),
+                    fmm::types::Pointer::new(reference_count::compile_type_with_reference_count(
+                        type_::compile_unsized_closure(declaration.type_(), types),
+                    )),
                 ),
             )
         }))
@@ -130,15 +126,13 @@ fn compile_global_variables(
             (
                 definition.name().into(),
                 fmm::build::bit_cast(
-                    fmm::types::Pointer::new(
-                        reference_count::heap::compile_type_with_reference_count(
-                            type_::compile_unsized_closure(definition.type_(), types),
-                        ),
-                    ),
+                    fmm::types::Pointer::new(reference_count::compile_type_with_reference_count(
+                        type_::compile_unsized_closure(definition.type_(), types),
+                    )),
                     fmm::build::variable(
                         definition.name(),
                         fmm::types::Pointer::new(
-                            reference_count::heap::compile_type_with_reference_count(
+                            reference_count::compile_type_with_reference_count(
                                 type_::compile_sized_closure(definition, types),
                             ),
                         ),

--- a/lib/mir-fmm/src/lib.rs
+++ b/lib/mir-fmm/src/lib.rs
@@ -105,10 +105,11 @@ fn compile_global_variables(
                 declaration.name().into(),
                 fmm::build::variable(
                     declaration.name(),
-                    fmm::types::Pointer::new(type_::compile_unsized_closure(
-                        declaration.type_(),
-                        types,
-                    )),
+                    fmm::types::Pointer::new(
+                        reference_count::heap::compile_type_with_reference_count(
+                            type_::compile_unsized_closure(declaration.type_(), types),
+                        ),
+                    ),
                 ),
             )
         })
@@ -117,10 +118,11 @@ fn compile_global_variables(
                 declaration.name().into(),
                 fmm::build::variable(
                     declaration.name(),
-                    fmm::types::Pointer::new(type_::compile_unsized_closure(
-                        declaration.type_(),
-                        types,
-                    )),
+                    fmm::types::Pointer::new(
+                        reference_count::heap::compile_type_with_reference_count(
+                            type_::compile_unsized_closure(declaration.type_(), types),
+                        ),
+                    ),
                 ),
             )
         }))
@@ -128,19 +130,24 @@ fn compile_global_variables(
             (
                 definition.name().into(),
                 fmm::build::bit_cast(
-                    fmm::types::Pointer::new(type_::compile_unsized_closure(
-                        definition.type_(),
-                        types,
-                    )),
+                    fmm::types::Pointer::new(
+                        reference_count::heap::compile_type_with_reference_count(
+                            type_::compile_unsized_closure(definition.type_(), types),
+                        ),
+                    ),
                     fmm::build::variable(
                         definition.name(),
-                        fmm::types::Pointer::new(type_::compile_sized_closure(definition, types)),
+                        fmm::types::Pointer::new(
+                            reference_count::heap::compile_type_with_reference_count(
+                                type_::compile_sized_closure(definition, types),
+                            ),
+                        ),
                     ),
                 )
                 .into(),
             )
         }))
-        .map(|(name, expression)| Ok((name, reference_count::pointer::tag_as_static(&expression)?)))
+        .map(|(name, expression)| Ok((name, fmm::build::record_address(expression, 1)?.into())))
         .collect::<Result<_, _>>()
 }
 

--- a/lib/mir-fmm/src/lib.rs
+++ b/lib/mir-fmm/src/lib.rs
@@ -105,7 +105,7 @@ fn compile_global_variables(
                 declaration.name().into(),
                 fmm::build::variable(
                     declaration.name(),
-                    fmm::types::Pointer::new(reference_count::compile_type_with_reference_count(
+                    fmm::types::Pointer::new(reference_count::block::compile_type(
                         type_::compile_unsized_closure(declaration.type_(), types),
                     )),
                 ),
@@ -116,7 +116,7 @@ fn compile_global_variables(
                 declaration.name().into(),
                 fmm::build::variable(
                     declaration.name(),
-                    fmm::types::Pointer::new(reference_count::compile_type_with_reference_count(
+                    fmm::types::Pointer::new(reference_count::block::compile_type(
                         type_::compile_unsized_closure(declaration.type_(), types),
                     )),
                 ),
@@ -126,16 +126,14 @@ fn compile_global_variables(
             (
                 definition.name().into(),
                 fmm::build::bit_cast(
-                    fmm::types::Pointer::new(reference_count::compile_type_with_reference_count(
+                    fmm::types::Pointer::new(reference_count::block::compile_type(
                         type_::compile_unsized_closure(definition.type_(), types),
                     )),
                     fmm::build::variable(
                         definition.name(),
-                        fmm::types::Pointer::new(
-                            reference_count::compile_type_with_reference_count(
-                                type_::compile_sized_closure(definition, types),
-                            ),
-                        ),
+                        fmm::types::Pointer::new(reference_count::block::compile_type(
+                            type_::compile_sized_closure(definition, types),
+                        )),
                     ),
                 )
                 .into(),

--- a/lib/mir-fmm/src/reference_count.rs
+++ b/lib/mir-fmm/src/reference_count.rs
@@ -1,3 +1,4 @@
+pub mod block;
 mod count;
 mod expression;
 mod function;
@@ -6,15 +7,4 @@ pub mod pointer;
 pub mod record;
 pub mod variant;
 
-use crate::CompileError;
 pub use expression::*;
-
-pub fn compile_static(
-    expression: impl Into<fmm::build::TypedExpression>,
-) -> Result<fmm::build::TypedExpression, CompileError> {
-    Ok(fmm::build::record(vec![count::compile_static()?, expression.into()]).into())
-}
-
-pub fn compile_type_with_reference_count(type_: impl Into<fmm::types::Type>) -> fmm::types::Record {
-    fmm::types::Record::new(vec![count::compile_type().into(), type_.into()])
-}

--- a/lib/mir-fmm/src/reference_count.rs
+++ b/lib/mir-fmm/src/reference_count.rs
@@ -1,4 +1,4 @@
-mod count;
+pub mod count;
 mod expression;
 pub mod function;
 pub mod heap;

--- a/lib/mir-fmm/src/reference_count.rs
+++ b/lib/mir-fmm/src/reference_count.rs
@@ -1,9 +1,20 @@
-pub mod count;
+mod count;
 mod expression;
-pub mod function;
+mod function;
 pub mod heap;
 pub mod pointer;
 pub mod record;
 pub mod variant;
 
+use crate::CompileError;
 pub use expression::*;
+
+pub fn compile_static(
+    expression: impl Into<fmm::build::TypedExpression>,
+) -> Result<fmm::build::TypedExpression, CompileError> {
+    Ok(fmm::build::record(vec![count::compile_static()?.into(), expression.into()]).into())
+}
+
+pub fn compile_type_with_reference_count(type_: impl Into<fmm::types::Type>) -> fmm::types::Record {
+    fmm::types::Record::new(vec![count::compile_type().into(), type_.into()])
+}

--- a/lib/mir-fmm/src/reference_count.rs
+++ b/lib/mir-fmm/src/reference_count.rs
@@ -12,7 +12,7 @@ pub use expression::*;
 pub fn compile_static(
     expression: impl Into<fmm::build::TypedExpression>,
 ) -> Result<fmm::build::TypedExpression, CompileError> {
-    Ok(fmm::build::record(vec![count::compile_static()?.into(), expression.into()]).into())
+    Ok(fmm::build::record(vec![count::compile_static()?, expression.into()]).into())
 }
 
 pub fn compile_type_with_reference_count(type_: impl Into<fmm::types::Type>) -> fmm::types::Record {

--- a/lib/mir-fmm/src/reference_count/block.rs
+++ b/lib/mir-fmm/src/reference_count/block.rs
@@ -1,0 +1,25 @@
+use super::count;
+use crate::CompileError;
+
+pub fn compile_static(
+    expression: impl Into<fmm::build::TypedExpression>,
+) -> Result<fmm::build::TypedExpression, CompileError> {
+    Ok(fmm::build::record(vec![count::compile_static()?, expression.into()]).into())
+}
+
+pub fn compile_type(type_: impl Into<fmm::types::Type>) -> fmm::types::Record {
+    fmm::types::Record::new(vec![count::compile_type().into(), type_.into()])
+}
+
+pub fn compile_count_pointer(
+    block_pointer: &fmm::build::TypedExpression,
+) -> Result<fmm::build::TypedExpression, fmm::build::BuildError> {
+    Ok(fmm::build::pointer_address(
+        fmm::build::bit_cast(
+            fmm::types::Pointer::new(count::compile_type()),
+            block_pointer.clone(),
+        ),
+        fmm::ir::Primitive::PointerInteger(-1),
+    )?
+    .into())
+}

--- a/lib/mir-fmm/src/reference_count/count.rs
+++ b/lib/mir-fmm/src/reference_count/count.rs
@@ -68,30 +68,13 @@ pub fn sticky_count() -> Result<fmm::build::TypedExpression, CompileError> {
         fmm::ir::BitwiseOperator::LeftShift,
         fmm::ir::Primitive::PointerInteger(1),
         fmm::build::arithmetic_operation(
-            fmm::ir::ArithmeticOperator::Divide,
+            fmm::ir::ArithmeticOperator::Subtract,
             fmm::build::arithmetic_operation(
                 fmm::ir::ArithmeticOperator::Multiply,
                 fmm::build::size_of(compile_type()),
                 fmm::ir::Primitive::PointerInteger(8),
             )?,
-            fmm::ir::Primitive::PointerInteger(2),
-        )?,
-    )?
-    .into())
-}
-
-pub fn drop_sticky_count() -> Result<fmm::build::TypedExpression, CompileError> {
-    Ok(fmm::build::bitwise_operation(
-        fmm::ir::BitwiseOperator::LeftShift,
-        fmm::ir::Primitive::PointerInteger(1),
-        fmm::build::arithmetic_operation(
-            fmm::ir::ArithmeticOperator::Divide,
-            fmm::build::arithmetic_operation(
-                fmm::ir::ArithmeticOperator::Multiply,
-                fmm::build::size_of(compile_type()),
-                fmm::ir::Primitive::PointerInteger(8),
-            )?,
-            fmm::ir::Primitive::PointerInteger(2),
+            fmm::ir::Primitive::PointerInteger(1),
         )?,
     )?
     .into())

--- a/lib/mir-fmm/src/reference_count/count.rs
+++ b/lib/mir-fmm/src/reference_count/count.rs
@@ -63,7 +63,7 @@ pub fn is_synchronized_unique(
     .into())
 }
 
-pub fn static_count() -> Result<fmm::build::TypedExpression, CompileError> {
+pub fn compile_static() -> Result<fmm::build::TypedExpression, CompileError> {
     Ok(fmm::build::bitwise_operation(
         fmm::ir::BitwiseOperator::LeftShift,
         fmm::ir::Primitive::PointerInteger(1),

--- a/lib/mir-fmm/src/reference_count/count.rs
+++ b/lib/mir-fmm/src/reference_count/count.rs
@@ -63,6 +63,17 @@ pub fn is_synchronized_unique(
     .into())
 }
 
+pub fn is_static(
+    count: &fmm::build::TypedExpression,
+) -> Result<fmm::build::TypedExpression, CompileError> {
+    Ok(fmm::build::comparison_operation(
+        fmm::ir::ComparisonOperator::Equal,
+        count.clone(),
+        compile_static()?,
+    )?
+    .into())
+}
+
 pub fn compile_static() -> Result<fmm::build::TypedExpression, CompileError> {
     Ok(fmm::build::bitwise_operation(
         fmm::ir::BitwiseOperator::LeftShift,

--- a/lib/mir-fmm/src/reference_count/count.rs
+++ b/lib/mir-fmm/src/reference_count/count.rs
@@ -63,7 +63,7 @@ pub fn is_synchronized_unique(
     .into())
 }
 
-pub fn sticky_count() -> Result<fmm::build::TypedExpression, CompileError> {
+pub fn static_count() -> Result<fmm::build::TypedExpression, CompileError> {
     Ok(fmm::build::bitwise_operation(
         fmm::ir::BitwiseOperator::LeftShift,
         fmm::ir::Primitive::PointerInteger(1),

--- a/lib/mir-fmm/src/reference_count/count.rs
+++ b/lib/mir-fmm/src/reference_count/count.rs
@@ -62,3 +62,37 @@ pub fn is_synchronized_unique(
     )?
     .into())
 }
+
+pub fn sticky_count() -> Result<fmm::build::TypedExpression, CompileError> {
+    Ok(fmm::build::bitwise_operation(
+        fmm::ir::BitwiseOperator::LeftShift,
+        fmm::ir::Primitive::PointerInteger(1),
+        fmm::build::arithmetic_operation(
+            fmm::ir::ArithmeticOperator::Divide,
+            fmm::build::arithmetic_operation(
+                fmm::ir::ArithmeticOperator::Multiply,
+                fmm::build::size_of(compile_type()),
+                fmm::ir::Primitive::PointerInteger(8),
+            )?,
+            fmm::ir::Primitive::PointerInteger(2),
+        )?,
+    )?
+    .into())
+}
+
+pub fn drop_sticky_count() -> Result<fmm::build::TypedExpression, CompileError> {
+    Ok(fmm::build::bitwise_operation(
+        fmm::ir::BitwiseOperator::LeftShift,
+        fmm::ir::Primitive::PointerInteger(1),
+        fmm::build::arithmetic_operation(
+            fmm::ir::ArithmeticOperator::Divide,
+            fmm::build::arithmetic_operation(
+                fmm::ir::ArithmeticOperator::Multiply,
+                fmm::build::size_of(compile_type()),
+                fmm::ir::Primitive::PointerInteger(8),
+            )?,
+            fmm::ir::Primitive::PointerInteger(2),
+        )?,
+    )?
+    .into())
+}

--- a/lib/mir-fmm/src/reference_count/heap.rs
+++ b/lib/mir-fmm/src/reference_count/heap.rs
@@ -1,5 +1,9 @@
 use super::{super::error::CompileError, count};
 
+pub fn compile_type_with_reference_count(type_: impl Into<fmm::types::Type>) -> fmm::types::Record {
+    fmm::types::Record::new(vec![count::compile_type().into(), type_.into()])
+}
+
 pub fn allocate(
     builder: &fmm::build::InstructionBuilder,
     type_: impl Into<fmm::types::Type>,

--- a/lib/mir-fmm/src/reference_count/heap.rs
+++ b/lib/mir-fmm/src/reference_count/heap.rs
@@ -1,4 +1,4 @@
-use super::{super::error::CompileError, count};
+use super::{super::error::CompileError, block, count};
 
 pub fn allocate(
     builder: &fmm::build::InstructionBuilder,
@@ -30,21 +30,8 @@ pub fn free(
 ) -> Result<(), CompileError> {
     builder.free_heap(fmm::build::bit_cast(
         fmm::types::generic_pointer_type(),
-        get_count_pointer(&pointer.into())?,
+        block::compile_count_pointer(&pointer.into())?,
     ));
 
     Ok(())
-}
-
-pub fn get_count_pointer(
-    pointer: &fmm::build::TypedExpression,
-) -> Result<fmm::build::TypedExpression, fmm::build::BuildError> {
-    Ok(fmm::build::pointer_address(
-        fmm::build::bit_cast(
-            fmm::types::Pointer::new(count::compile_type()),
-            pointer.clone(),
-        ),
-        fmm::ir::Primitive::PointerInteger(-1),
-    )?
-    .into())
 }

--- a/lib/mir-fmm/src/reference_count/heap.rs
+++ b/lib/mir-fmm/src/reference_count/heap.rs
@@ -1,9 +1,5 @@
 use super::{super::error::CompileError, count};
 
-pub fn compile_type_with_reference_count(type_: impl Into<fmm::types::Type>) -> fmm::types::Record {
-    fmm::types::Record::new(vec![count::compile_type().into(), type_.into()])
-}
-
 pub fn allocate(
     builder: &fmm::build::InstructionBuilder,
     type_: impl Into<fmm::types::Type>,

--- a/lib/mir-fmm/src/reference_count/pointer.rs
+++ b/lib/mir-fmm/src/reference_count/pointer.rs
@@ -137,20 +137,6 @@ pub fn synchronize(
     Ok(())
 }
 
-pub fn untag(
-    pointer: &fmm::build::TypedExpression,
-) -> Result<fmm::build::TypedExpression, CompileError> {
-    Ok(fmm::build::bit_cast(
-        pointer.type_().clone(),
-        fmm::build::bitwise_operation(
-            fmm::ir::BitwiseOperator::And,
-            fmm::build::bit_cast(fmm::types::Primitive::PointerInteger, pointer.clone()),
-            fmm::build::bitwise_not_operation(fmm::ir::Primitive::PointerInteger(1))?,
-        )?,
-    )
-    .into())
-}
-
 pub fn is_unique(
     builder: &fmm::build::InstructionBuilder,
     pointer: &fmm::build::TypedExpression,

--- a/lib/mir-fmm/src/reference_count/pointer.rs
+++ b/lib/mir-fmm/src/reference_count/pointer.rs
@@ -3,6 +3,8 @@ use super::{super::error::CompileError, count, heap};
 // Reference counts are negative for synchronized memory blocks and otherwise
 // positive. References to static memory blocks are tagged.
 
+// TODO Implement sticky count ranges.
+
 pub fn clone(
     builder: &fmm::build::InstructionBuilder,
     pointer: &fmm::build::TypedExpression,

--- a/lib/mir-fmm/src/reference_count/pointer.rs
+++ b/lib/mir-fmm/src/reference_count/pointer.rs
@@ -137,20 +137,6 @@ pub fn synchronize(
     Ok(())
 }
 
-pub fn tag_as_static(
-    pointer: &fmm::build::TypedExpression,
-) -> Result<fmm::build::TypedExpression, CompileError> {
-    Ok(fmm::build::bit_cast(
-        pointer.type_().clone(),
-        fmm::build::bitwise_operation(
-            fmm::ir::BitwiseOperator::Or,
-            fmm::build::bit_cast(fmm::types::Primitive::PointerInteger, pointer.clone()),
-            fmm::ir::Primitive::PointerInteger(1),
-        )?,
-    )
-    .into())
-}
-
 pub fn untag(
     pointer: &fmm::build::TypedExpression,
 ) -> Result<fmm::build::TypedExpression, CompileError> {

--- a/lib/mir-fmm/src/reference_count/pointer.rs
+++ b/lib/mir-fmm/src/reference_count/pointer.rs
@@ -185,18 +185,16 @@ pub fn is_synchronized(
     builder: &fmm::build::InstructionBuilder,
     pointer: &fmm::build::TypedExpression,
 ) -> Result<fmm::build::TypedExpression, CompileError> {
-    Ok(builder
-        .if_(
-            is_null(pointer)?,
-            |builder| Ok(builder.branch(fmm::ir::Primitive::Boolean(false))),
-            |builder| -> Result<_, CompileError> {
-                Ok(builder.branch(count::is_synchronized(&builder.atomic_load(
-                    heap::get_count_pointer(pointer)?,
-                    fmm::ir::AtomicOrdering::Relaxed,
-                )?)?))
-            },
-        )?
-        .into())
+    builder.if_(
+        is_null(pointer)?,
+        |builder| Ok(builder.branch(fmm::ir::Primitive::Boolean(false))),
+        |builder| -> Result<_, CompileError> {
+            Ok(builder.branch(count::is_synchronized(&builder.atomic_load(
+                heap::get_count_pointer(pointer)?,
+                fmm::ir::AtomicOrdering::Relaxed,
+            )?)?))
+        },
+    )
 }
 
 fn is_null(

--- a/lib/mir-fmm/src/reference_count/pointer.rs
+++ b/lib/mir-fmm/src/reference_count/pointer.rs
@@ -3,8 +3,6 @@ use super::{super::error::CompileError, count, heap};
 // Reference counts are negative for synchronized memory blocks and otherwise
 // positive. References to static memory blocks are tagged.
 
-// TODO Implement sticky count ranges.
-
 pub fn clone(
     builder: &fmm::build::InstructionBuilder,
     pointer: &fmm::build::TypedExpression,

--- a/lib/mir-fmm/src/snapshots/mir_fmm__entry_function__tests__do_not_overwrite_global_functions_in_variables.snap
+++ b/lib/mir-fmm/src/snapshots/mir_fmm__entry_function__tests__do_not_overwrite_global_functions_in_variables.snap
@@ -5,22 +5,22 @@ expression: "fmm::analysis::format_module(&context.module_builder().as_module())
 (module
   (function _fmm_2 _closure
     (block
-      (atomic-load (record-address (bit-cast (& (bit-cast f) (bit! 1))) 0) _fmm_3)
+      (atomic-load (record-address f 0) _fmm_3)
       (call _fmm_3 (bit-cast f) _fmm_4)
       (return _fmm_4)))
   (function _fmm_5 _closure
     (block
-      (load (bit-cast (record-address (bit-cast (& (bit-cast (bit-cast _closure)) (bit! 1))) 2)) _fmm_6)
+      (load (bit-cast (record-address (bit-cast _closure) 2)) _fmm_6)
       (return (record))))
   (function _fmm_7 _closure
     (block
-      (load (bit-cast (record-address (bit-cast (& (bit-cast (bit-cast _closure)) (bit! 1))) 2)) _fmm_8)
+      (load (bit-cast (record-address (bit-cast _closure) 2)) _fmm_8)
       (return (record))))
   (function _fmm_0 _closure
     (block
       (allocate-heap (size-of record) _fmm_1)
       (store 0 (record-address (bit-cast _fmm_1) 0))
       (store (record _fmm_2 _fmm_9 (record)) (record-address (bit-cast _fmm_1) 1))
-      (atomic-load (record-address (bit-cast (& (bit-cast (bit-cast (record-address (bit-cast _fmm_1) 1))) (bit! 1))) 0) _fmm_a)
+      (atomic-load (record-address (bit-cast (record-address (bit-cast _fmm_1) 1)) 0) _fmm_a)
       (call _fmm_a (bit-cast (bit-cast (record-address (bit-cast _fmm_1) 1))) _fmm_b)
       (return _fmm_b))))

--- a/packages/core/ffi/Cargo.lock
+++ b/packages/core/ffi/Cargo.lock
@@ -133,9 +133,9 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "pen-ffi"
-version = "0.6.7"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b72d9ee85dc3c158f5dd37d9edc0e897e467b839cac6bb1f6ca8b98ddcd754db"
+checksum = "2ea360568d5fab450011e7d61d5cf2b294a8b560b87b5c19d5ad1a343aa25f9d"
 dependencies = [
  "async-stream",
  "futures",

--- a/packages/http/ffi/Cargo.lock
+++ b/packages/http/ffi/Cargo.lock
@@ -191,9 +191,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db0d4cf898abf0081f964436dc980e96670a0f36863e4b83aaacdb65c9d7ccc3"
+checksum = "607c8a29735385251a339424dd462993c0fed8fa09d378f259377df08c126022"
 dependencies = [
  "ahash",
 ]
@@ -243,9 +243,9 @@ checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
 name = "hyper"
-version = "0.14.19"
+version = "0.14.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42dc3c131584288d375f2d07f822b0cb012d8c6fb899a5b9fdb3cb7eb9b6004f"
+checksum = "02c929dc5c39e335a03c405292728118860721b10190d98c2a0f0efd5baafbac"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -336,9 +336,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7709cef83f0c1f58f666e746a08b21e0085f7440fa6a29cc194d68aac97a4225"
+checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
 
 [[package]]
 name = "parking_lot"
@@ -365,9 +365,9 @@ dependencies = [
 
 [[package]]
 name = "pen-ffi"
-version = "0.6.5"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe1c76f2b4750111704f5be6d43274918e1cfbbb164dc4d700f5fc23646a685"
+checksum = "2ea360568d5fab450011e7d61d5cf2b294a8b560b87b5c19d5ad1a343aa25f9d"
 dependencies = [
  "async-stream",
  "futures",
@@ -486,10 +486,11 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.19.2"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c51a52ed6686dd62c320f9b89299e9dfb46f730c7a48e635c19f21d116cb1439"
+checksum = "57aec3cfa4c296db7255446efb4928a6be304b431a806216105542a67b6ca82e"
 dependencies = [
+ "autocfg",
  "bytes",
  "libc",
  "memchr",

--- a/packages/json/ffi/Cargo.lock
+++ b/packages/json/ffi/Cargo.lock
@@ -133,9 +133,9 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "pen-ffi"
-version = "0.6.5"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe1c76f2b4750111704f5be6d43274918e1cfbbb164dc4d700f5fc23646a685"
+checksum = "2ea360568d5fab450011e7d61d5cf2b294a8b560b87b5c19d5ad1a343aa25f9d"
 dependencies = [
  "async-stream",
  "futures",

--- a/packages/os-sync/ffi/Cargo.lock
+++ b/packages/os-sync/ffi/Cargo.lock
@@ -173,9 +173,9 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "once_cell"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7709cef83f0c1f58f666e746a08b21e0085f7440fa6a29cc194d68aac97a4225"
+checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
 
 [[package]]
 name = "os"
@@ -196,9 +196,9 @@ dependencies = [
 
 [[package]]
 name = "pen-ffi"
-version = "0.6.5"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe1c76f2b4750111704f5be6d43274918e1cfbbb164dc4d700f5fc23646a685"
+checksum = "2ea360568d5fab450011e7d61d5cf2b294a8b560b87b5c19d5ad1a343aa25f9d"
 dependencies = [
  "async-stream",
  "futures",

--- a/packages/os/ffi/application/Cargo.lock
+++ b/packages/os/ffi/application/Cargo.lock
@@ -166,9 +166,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db0d4cf898abf0081f964436dc980e96670a0f36863e4b83aaacdb65c9d7ccc3"
+checksum = "607c8a29735385251a339424dd462993c0fed8fa09d378f259377df08c126022"
 dependencies = [
  "ahash",
 ]
@@ -237,9 +237,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7709cef83f0c1f58f666e746a08b21e0085f7440fa6a29cc194d68aac97a4225"
+checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
 
 [[package]]
 name = "os-app"
@@ -275,9 +275,9 @@ dependencies = [
 
 [[package]]
 name = "pen-ffi"
-version = "0.6.5"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe1c76f2b4750111704f5be6d43274918e1cfbbb164dc4d700f5fc23646a685"
+checksum = "2ea360568d5fab450011e7d61d5cf2b294a8b560b87b5c19d5ad1a343aa25f9d"
 dependencies = [
  "async-stream",
  "futures",
@@ -386,10 +386,11 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.19.2"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c51a52ed6686dd62c320f9b89299e9dfb46f730c7a48e635c19f21d116cb1439"
+checksum = "57aec3cfa4c296db7255446efb4928a6be304b431a806216105542a67b6ca82e"
 dependencies = [
+ "autocfg",
  "bytes",
  "libc",
  "memchr",

--- a/packages/os/ffi/library/Cargo.lock
+++ b/packages/os/ffi/library/Cargo.lock
@@ -166,9 +166,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db0d4cf898abf0081f964436dc980e96670a0f36863e4b83aaacdb65c9d7ccc3"
+checksum = "607c8a29735385251a339424dd462993c0fed8fa09d378f259377df08c126022"
 dependencies = [
  "ahash",
 ]
@@ -237,9 +237,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7709cef83f0c1f58f666e746a08b21e0085f7440fa6a29cc194d68aac97a4225"
+checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
 
 [[package]]
 name = "os"
@@ -276,9 +276,9 @@ dependencies = [
 
 [[package]]
 name = "pen-ffi"
-version = "0.6.5"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe1c76f2b4750111704f5be6d43274918e1cfbbb164dc4d700f5fc23646a685"
+checksum = "2ea360568d5fab450011e7d61d5cf2b294a8b560b87b5c19d5ad1a343aa25f9d"
 dependencies = [
  "async-stream",
  "futures",
@@ -423,10 +423,11 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.19.2"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c51a52ed6686dd62c320f9b89299e9dfb46f730c7a48e635c19f21d116cb1439"
+checksum = "57aec3cfa4c296db7255446efb4928a6be304b431a806216105542a67b6ca82e"
 dependencies = [
+ "autocfg",
  "bytes",
  "libc",
  "memchr",

--- a/packages/prelude/ffi/Cargo.lock
+++ b/packages/prelude/ffi/Cargo.lock
@@ -126,9 +126,9 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "pen-ffi"
-version = "0.6.5"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe1c76f2b4750111704f5be6d43274918e1cfbbb164dc4d700f5fc23646a685"
+checksum = "2ea360568d5fab450011e7d61d5cf2b294a8b560b87b5c19d5ad1a343aa25f9d"
 dependencies = [
  "async-stream",
  "futures",

--- a/packages/sql/ffi/Cargo.lock
+++ b/packages/sql/ffi/Cargo.lock
@@ -251,7 +251,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "pin-project",
- "spin 0.9.3",
+ "spin 0.9.4",
 ]
 
 [[package]]
@@ -739,9 +739,9 @@ dependencies = [
 
 [[package]]
 name = "pen-ffi"
-version = "0.6.7"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b72d9ee85dc3c158f5dd37d9edc0e897e467b839cac6bb1f6ca8b98ddcd754db"
+checksum = "2ea360568d5fab450011e7d61d5cf2b294a8b560b87b5c19d5ad1a343aa25f9d"
 dependencies = [
  "async-stream",
  "futures",
@@ -1080,9 +1080,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c530c2b0d0bf8b69304b39fe2001993e267461948b890cd037d8ad4293fa1a0d"
+checksum = "7f6002a767bff9e83f8eeecf883ecb8011875a21ae8da43bffb817a57e78cc09"
 dependencies = [
  "lock_api",
 ]
@@ -1111,7 +1111,7 @@ dependencies = [
 [[package]]
 name = "sqlx"
 version = "0.6.0"
-source = "git+https://github.com/raviqqe/sqlx?branch=bug/any-type-info#4d17b202446af0cc9d5e0b2ba8b9574b5142cd16"
+source = "git+https://github.com/launchbadge/sqlx#9534de3476ed7e40d390b7713208b686c8e7366a"
 dependencies = [
  "sqlx-core",
  "sqlx-macros",
@@ -1120,7 +1120,7 @@ dependencies = [
 [[package]]
 name = "sqlx-core"
 version = "0.6.0"
-source = "git+https://github.com/raviqqe/sqlx?branch=bug/any-type-info#4d17b202446af0cc9d5e0b2ba8b9574b5142cd16"
+source = "git+https://github.com/launchbadge/sqlx#9534de3476ed7e40d390b7713208b686c8e7366a"
 dependencies = [
  "ahash",
  "atoi",
@@ -1178,7 +1178,7 @@ dependencies = [
 [[package]]
 name = "sqlx-macros"
 version = "0.6.0"
-source = "git+https://github.com/raviqqe/sqlx?branch=bug/any-type-info#4d17b202446af0cc9d5e0b2ba8b9574b5142cd16"
+source = "git+https://github.com/launchbadge/sqlx#9534de3476ed7e40d390b7713208b686c8e7366a"
 dependencies = [
  "dotenv",
  "either",
@@ -1196,7 +1196,7 @@ dependencies = [
 [[package]]
 name = "sqlx-rt"
 version = "0.6.0"
-source = "git+https://github.com/raviqqe/sqlx?branch=bug/any-type-info#4d17b202446af0cc9d5e0b2ba8b9574b5142cd16"
+source = "git+https://github.com/launchbadge/sqlx#9534de3476ed7e40d390b7713208b686c8e7366a"
 dependencies = [
  "once_cell",
  "tokio",
@@ -1267,10 +1267,11 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.19.2"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c51a52ed6686dd62c320f9b89299e9dfb46f730c7a48e635c19f21d116cb1439"
+checksum = "57aec3cfa4c296db7255446efb4928a6be304b431a806216105542a67b6ca82e"
 dependencies = [
+ "autocfg",
  "bytes",
  "libc",
  "memchr",


### PR DESCRIPTION
We do not implement sticky reference count ranges like [Koka](https://github.com/koka-lang/koka) but only static counts because we can use full bits of pointer-sized integers for reference counts on both 32-bit and 64-bit platforms.