### PR TITLE
Fix slow compilation with large map literals

### DIFF
--- a/lib/hir-mir/src/expression.rs
+++ b/lib/hir-mir/src/expression.rs
@@ -80,18 +80,15 @@ pub fn compile(
                 })
                 .collect(),
             if let Some(branch) = if_.else_() {
-                if type_equality_checker::check(
+                type_equality_checker::check(
                     branch.type_().unwrap(),
                     &types::Any::new(if_.position().clone()).into(),
                     context.types(),
-                )? {
-                    Some(mir::ir::DefaultAlternative::new(
-                        if_.name(),
-                        compile(branch.expression())?,
-                    ))
-                } else {
-                    None
-                }
+                )?
+                .then_some(mir::ir::DefaultAlternative::new(
+                    if_.name(),
+                    compile(branch.expression())?,
+                ))
             } else {
                 None
             },

--- a/lib/hir-mir/src/expression.rs
+++ b/lib/hir-mir/src/expression.rs
@@ -80,15 +80,18 @@ pub fn compile(
                 })
                 .collect(),
             if let Some(branch) = if_.else_() {
-                type_equality_checker::check(
+                if type_equality_checker::check(
                     branch.type_().unwrap(),
                     &types::Any::new(if_.position().clone()).into(),
                     context.types(),
-                )?
-                .then_some(mir::ir::DefaultAlternative::new(
-                    if_.name(),
-                    compile(branch.expression())?,
-                ))
+                )? {
+                    Some(mir::ir::DefaultAlternative::new(
+                        if_.name(),
+                        compile(branch.expression())?,
+                    ))
+                } else {
+                    None
+                }
             } else {
                 None
             },

--- a/lib/hir-mir/src/transformation/equal_operation.rs
+++ b/lib/hir-mir/src/transformation/equal_operation.rs
@@ -221,9 +221,6 @@ fn transform_equal_operation(
     })
 }
 
-// TODO Do not generate equal functions dynamically but define them once
-// globally.
-// Can we simply lift them up to global functions as optimization in MIR?
 pub fn transform_any_function(
     context: &CompileContext,
     type_: &Type,

--- a/lib/hir-mir/src/transformation/map_context.rs
+++ b/lib/hir-mir/src/transformation/map_context.rs
@@ -3,6 +3,9 @@ use crate::{context::CompileContext, transformation::equal_operation, CompileErr
 use hir::{analysis::type_comparability_checker, ir::*, types, types::Type};
 use position::Position;
 
+// TODO Do not generate equal functions dynamically but define them once
+// globally.
+// Can we simply lift them up to global functions as optimization in MIR?
 pub fn transform(
     context: &CompileContext,
     key_type: &Type,

--- a/lib/hir-mir/src/transformation/map_literal.rs
+++ b/lib/hir-mir/src/transformation/map_literal.rs
@@ -182,6 +182,32 @@ mod tests {
     }
 
     #[test]
+    fn transform_map_with_2_entries() {
+        insta::assert_debug_snapshot!(transform(
+            &CompileContext::dummy(Default::default(), Default::default()),
+            &Map::new(
+                types::None::new(Position::fake()),
+                types::None::new(Position::fake()),
+                vec![
+                    MapEntry::new(
+                        Number::new(1.0, Position::fake()),
+                        None::new(Position::fake()),
+                        Position::fake()
+                    )
+                    .into(),
+                    MapEntry::new(
+                        Number::new(2.0, Position::fake()),
+                        None::new(Position::fake()),
+                        Position::fake()
+                    )
+                    .into()
+                ],
+                Position::fake()
+            ),
+        ));
+    }
+
+    #[test]
     fn transform_map_with_spread_map() {
         assert_eq!(
             transform(

--- a/lib/hir-mir/src/transformation/map_literal.rs
+++ b/lib/hir-mir/src/transformation/map_literal.rs
@@ -6,27 +6,44 @@ use hir::{
 };
 use position::Position;
 
+const CONTEXT_VARIABLE_NAME: &str = "$ctx";
+
 pub fn transform(context: &CompileContext, map: &Map) -> Result<Expression, CompileError> {
-    transform_map(
-        context,
-        map.key_type(),
-        map.value_type(),
-        map.elements(),
-        map.position(),
+    let key_type = map.key_type();
+    let value_type = map.value_type();
+    let position = map.position();
+
+    let map_context_type = collection_type::transform_map_context(context, position)?;
+
+    Ok(Let::new(
+        Some(CONTEXT_VARIABLE_NAME.into()),
+        Some(map_context_type.clone()),
+        map_context::transform(context, key_type, value_type, position)?,
+        transform_map(
+            context,
+            &Variable::new(CONTEXT_VARIABLE_NAME, position.clone()).into(),
+            &map_context_type,
+            key_type,
+            value_type,
+            map.elements(),
+            position,
+        )?,
+        position.clone(),
     )
+    .into())
 }
 
 fn transform_map(
     context: &CompileContext,
+    map_context: &Expression,
+    map_context_type: &Type,
     key_type: &Type,
     value_type: &Type,
     elements: &[MapElement],
     position: &Position,
 ) -> Result<Expression, CompileError> {
     let configuration = &context.configuration()?.map_type;
-    let map_context_type = collection_type::transform_map_context(context, position)?;
     let any_map_type = collection_type::transform_map(context, position)?;
-    let map_context = map_context::transform(context, key_type, value_type, position)?;
 
     Ok(match elements {
         [] => Call::new(
@@ -42,6 +59,8 @@ fn transform_map(
         [.., element] => {
             let rest_expression = transform_map(
                 context,
+                map_context,
+                map_context_type,
                 key_type,
                 value_type,
                 &elements[..elements.len() - 1],
@@ -53,7 +72,7 @@ fn transform_map(
                     Some(
                         types::Function::new(
                             vec![
-                                map_context_type,
+                                map_context_type.clone(),
                                 any_map_type.clone(),
                                 types::Any::new(position.clone()).into(),
                                 types::Any::new(position.clone()).into(),
@@ -65,7 +84,7 @@ fn transform_map(
                     ),
                     Variable::new(&configuration.set_function_name, position.clone()),
                     vec![
-                        map_context,
+                        map_context.clone(),
                         rest_expression,
                         TypeCoercion::new(
                             key_type.clone(),
@@ -88,14 +107,18 @@ fn transform_map(
                 MapElement::Map(expression) => Call::new(
                     Some(
                         types::Function::new(
-                            vec![map_context_type, any_map_type.clone(), any_map_type.clone()],
+                            vec![
+                                map_context_type.clone(),
+                                any_map_type.clone(),
+                                any_map_type.clone(),
+                            ],
                             any_map_type,
                             position.clone(),
                         )
                         .into(),
                     ),
                     Variable::new(&configuration.merge_function_name, position.clone()),
-                    vec![map_context, expression.clone(), rest_expression],
+                    vec![map_context.clone(), expression.clone(), rest_expression],
                     position.clone(),
                 )
                 .into(),
@@ -103,7 +126,7 @@ fn transform_map(
                     Some(
                         types::Function::new(
                             vec![
-                                map_context_type,
+                                map_context_type.clone(),
                                 any_map_type.clone(),
                                 types::Any::new(position.clone()).into(),
                             ],
@@ -114,7 +137,7 @@ fn transform_map(
                     ),
                     Variable::new(&configuration.delete_function_name, position.clone()),
                     vec![
-                        map_context,
+                        map_context.clone(),
                         rest_expression,
                         TypeCoercion::new(
                             key_type.clone(),
@@ -209,17 +232,14 @@ mod tests {
 
     #[test]
     fn transform_map_with_spread_map() {
-        assert_eq!(
-            transform(
-                &CompileContext::dummy(Default::default(), Default::default()),
-                &Map::new(
-                    types::None::new(Position::fake()),
-                    types::None::new(Position::fake()),
-                    vec![MapElement::Map(None::new(Position::fake()).into())],
-                    Position::fake()
-                ),
+        insta::assert_debug_snapshot!(transform(
+            &CompileContext::dummy(Default::default(), Default::default()),
+            &Map::new(
+                types::None::new(Position::fake()),
+                types::None::new(Position::fake()),
+                vec![MapElement::Map(None::new(Position::fake()).into())],
+                Position::fake()
             ),
-            Ok(None::new(Position::fake()).into())
-        );
+        ));
     }
 }

--- a/lib/hir-mir/src/transformation/snapshots/hir_mir__transformation__map_literal__tests__transform_empty_map_with_function_value.snap
+++ b/lib/hir-mir/src/transformation/snapshots/hir_mir__transformation__map_literal__tests__transform_empty_map_with_function_value.snap
@@ -3,23 +3,15 @@ source: lib/hir-mir/src/transformation/map_literal.rs
 expression: "transform(&CompileContext::dummy(Default::default(), Default::default()),\n    &Map::new(types::None::new(Position::fake()),\n            types::Function::new(vec![], types::None::new(Position::fake()),\n                Position::fake()), vec![], Position::fake()))"
 ---
 Ok(
-    Call(
-        Call {
-            function_type: Some(
-                Function(
-                    Function {
-                        arguments: [],
-                        result: Reference(
-                            Reference {
-                                name: "GenericMap",
-                                position: Position {
-                                    path: "",
-                                    line_number: 1,
-                                    column_number: 1,
-                                    line: "",
-                                },
-                            },
-                        ),
+    Let(
+        Let {
+            name: Some(
+                "$ctx",
+            ),
+            type_: Some(
+                Reference(
+                    Reference {
+                        name: "mapContext",
                         position: Position {
                             path: "",
                             line_number: 1,
@@ -29,9 +21,515 @@ Ok(
                     },
                 ),
             ),
-            function: Variable(
-                Variable {
-                    name: "emptyMap",
+            bound_expression: Call(
+                Call {
+                    function_type: Some(
+                        Function(
+                            Function {
+                                arguments: [
+                                    Function(
+                                        Function {
+                                            arguments: [
+                                                Any(
+                                                    Any {
+                                                        position: Position {
+                                                            path: "",
+                                                            line_number: 1,
+                                                            column_number: 1,
+                                                            line: "",
+                                                        },
+                                                    },
+                                                ),
+                                                Any(
+                                                    Any {
+                                                        position: Position {
+                                                            path: "",
+                                                            line_number: 1,
+                                                            column_number: 1,
+                                                            line: "",
+                                                        },
+                                                    },
+                                                ),
+                                            ],
+                                            result: Boolean(
+                                                Boolean {
+                                                    position: Position {
+                                                        path: "",
+                                                        line_number: 1,
+                                                        column_number: 1,
+                                                        line: "",
+                                                    },
+                                                },
+                                            ),
+                                            position: Position {
+                                                path: "",
+                                                line_number: 1,
+                                                column_number: 1,
+                                                line: "",
+                                            },
+                                        },
+                                    ),
+                                    Function(
+                                        Function {
+                                            arguments: [
+                                                Any(
+                                                    Any {
+                                                        position: Position {
+                                                            path: "",
+                                                            line_number: 1,
+                                                            column_number: 1,
+                                                            line: "",
+                                                        },
+                                                    },
+                                                ),
+                                            ],
+                                            result: Number(
+                                                Number {
+                                                    position: Position {
+                                                        path: "",
+                                                        line_number: 1,
+                                                        column_number: 1,
+                                                        line: "",
+                                                    },
+                                                },
+                                            ),
+                                            position: Position {
+                                                path: "",
+                                                line_number: 1,
+                                                column_number: 1,
+                                                line: "",
+                                            },
+                                        },
+                                    ),
+                                    Function(
+                                        Function {
+                                            arguments: [
+                                                Any(
+                                                    Any {
+                                                        position: Position {
+                                                            path: "",
+                                                            line_number: 1,
+                                                            column_number: 1,
+                                                            line: "",
+                                                        },
+                                                    },
+                                                ),
+                                                Any(
+                                                    Any {
+                                                        position: Position {
+                                                            path: "",
+                                                            line_number: 1,
+                                                            column_number: 1,
+                                                            line: "",
+                                                        },
+                                                    },
+                                                ),
+                                            ],
+                                            result: Boolean(
+                                                Boolean {
+                                                    position: Position {
+                                                        path: "",
+                                                        line_number: 1,
+                                                        column_number: 1,
+                                                        line: "",
+                                                    },
+                                                },
+                                            ),
+                                            position: Position {
+                                                path: "",
+                                                line_number: 1,
+                                                column_number: 1,
+                                                line: "",
+                                            },
+                                        },
+                                    ),
+                                    Function(
+                                        Function {
+                                            arguments: [
+                                                Any(
+                                                    Any {
+                                                        position: Position {
+                                                            path: "",
+                                                            line_number: 1,
+                                                            column_number: 1,
+                                                            line: "",
+                                                        },
+                                                    },
+                                                ),
+                                            ],
+                                            result: Number(
+                                                Number {
+                                                    position: Position {
+                                                        path: "",
+                                                        line_number: 1,
+                                                        column_number: 1,
+                                                        line: "",
+                                                    },
+                                                },
+                                            ),
+                                            position: Position {
+                                                path: "",
+                                                line_number: 1,
+                                                column_number: 1,
+                                                line: "",
+                                            },
+                                        },
+                                    ),
+                                ],
+                                result: Reference(
+                                    Reference {
+                                        name: "mapContext",
+                                        position: Position {
+                                            path: "",
+                                            line_number: 1,
+                                            column_number: 1,
+                                            line: "",
+                                        },
+                                    },
+                                ),
+                                position: Position {
+                                    path: "",
+                                    line_number: 1,
+                                    column_number: 1,
+                                    line: "",
+                                },
+                            },
+                        ),
+                    ),
+                    function: Variable(
+                        Variable {
+                            name: "newMapContext",
+                            position: Position {
+                                path: "",
+                                line_number: 1,
+                                column_number: 1,
+                                line: "",
+                            },
+                        },
+                    ),
+                    arguments: [
+                        Lambda(
+                            Lambda {
+                                arguments: [
+                                    Argument {
+                                        name: "$lhs",
+                                        type_: Any(
+                                            Any {
+                                                position: Position {
+                                                    path: "",
+                                                    line_number: 1,
+                                                    column_number: 1,
+                                                    line: "",
+                                                },
+                                            },
+                                        ),
+                                    },
+                                    Argument {
+                                        name: "$rhs",
+                                        type_: Any(
+                                            Any {
+                                                position: Position {
+                                                    path: "",
+                                                    line_number: 1,
+                                                    column_number: 1,
+                                                    line: "",
+                                                },
+                                            },
+                                        ),
+                                    },
+                                ],
+                                result_type: Boolean(
+                                    Boolean {
+                                        position: Position {
+                                            path: "",
+                                            line_number: 1,
+                                            column_number: 1,
+                                            line: "",
+                                        },
+                                    },
+                                ),
+                                body: IfType(
+                                    IfType {
+                                        name: "$lhs",
+                                        argument: Variable(
+                                            Variable {
+                                                name: "$lhs",
+                                                position: Position {
+                                                    path: "",
+                                                    line_number: 1,
+                                                    column_number: 1,
+                                                    line: "",
+                                                },
+                                            },
+                                        ),
+                                        branches: [
+                                            IfTypeBranch {
+                                                type_: None(
+                                                    None {
+                                                        position: Position {
+                                                            path: "",
+                                                            line_number: 1,
+                                                            column_number: 1,
+                                                            line: "",
+                                                        },
+                                                    },
+                                                ),
+                                                expression: IfType(
+                                                    IfType {
+                                                        name: "$rhs",
+                                                        argument: Variable(
+                                                            Variable {
+                                                                name: "$rhs",
+                                                                position: Position {
+                                                                    path: "",
+                                                                    line_number: 1,
+                                                                    column_number: 1,
+                                                                    line: "",
+                                                                },
+                                                            },
+                                                        ),
+                                                        branches: [
+                                                            IfTypeBranch {
+                                                                type_: None(
+                                                                    None {
+                                                                        position: Position {
+                                                                            path: "",
+                                                                            line_number: 1,
+                                                                            column_number: 1,
+                                                                            line: "",
+                                                                        },
+                                                                    },
+                                                                ),
+                                                                expression: Boolean(
+                                                                    Boolean {
+                                                                        value: true,
+                                                                        position: Position {
+                                                                            path: "",
+                                                                            line_number: 1,
+                                                                            column_number: 1,
+                                                                            line: "",
+                                                                        },
+                                                                    },
+                                                                ),
+                                                            },
+                                                        ],
+                                                        else_: None,
+                                                        position: Position {
+                                                            path: "",
+                                                            line_number: 1,
+                                                            column_number: 1,
+                                                            line: "",
+                                                        },
+                                                    },
+                                                ),
+                                            },
+                                        ],
+                                        else_: None,
+                                        position: Position {
+                                            path: "",
+                                            line_number: 1,
+                                            column_number: 1,
+                                            line: "",
+                                        },
+                                    },
+                                ),
+                                position: Position {
+                                    path: "",
+                                    line_number: 1,
+                                    column_number: 1,
+                                    line: "",
+                                },
+                            },
+                        ),
+                        Lambda(
+                            Lambda {
+                                arguments: [
+                                    Argument {
+                                        name: "$x",
+                                        type_: Any(
+                                            Any {
+                                                position: Position {
+                                                    path: "",
+                                                    line_number: 1,
+                                                    column_number: 1,
+                                                    line: "",
+                                                },
+                                            },
+                                        ),
+                                    },
+                                ],
+                                result_type: Number(
+                                    Number {
+                                        position: Position {
+                                            path: "",
+                                            line_number: 1,
+                                            column_number: 1,
+                                            line: "",
+                                        },
+                                    },
+                                ),
+                                body: IfType(
+                                    IfType {
+                                        name: "$x",
+                                        argument: Variable(
+                                            Variable {
+                                                name: "$x",
+                                                position: Position {
+                                                    path: "",
+                                                    line_number: 1,
+                                                    column_number: 1,
+                                                    line: "",
+                                                },
+                                            },
+                                        ),
+                                        branches: [
+                                            IfTypeBranch {
+                                                type_: None(
+                                                    None {
+                                                        position: Position {
+                                                            path: "",
+                                                            line_number: 1,
+                                                            column_number: 1,
+                                                            line: "",
+                                                        },
+                                                    },
+                                                ),
+                                                expression: Number(
+                                                    Number {
+                                                        value: 0.0,
+                                                        position: Position {
+                                                            path: "",
+                                                            line_number: 1,
+                                                            column_number: 1,
+                                                            line: "",
+                                                        },
+                                                    },
+                                                ),
+                                            },
+                                        ],
+                                        else_: None,
+                                        position: Position {
+                                            path: "",
+                                            line_number: 1,
+                                            column_number: 1,
+                                            line: "",
+                                        },
+                                    },
+                                ),
+                                position: Position {
+                                    path: "",
+                                    line_number: 1,
+                                    column_number: 1,
+                                    line: "",
+                                },
+                            },
+                        ),
+                        Lambda(
+                            Lambda {
+                                arguments: [
+                                    Argument {
+                                        name: "",
+                                        type_: Any(
+                                            Any {
+                                                position: Position {
+                                                    path: "",
+                                                    line_number: 1,
+                                                    column_number: 1,
+                                                    line: "",
+                                                },
+                                            },
+                                        ),
+                                    },
+                                    Argument {
+                                        name: "",
+                                        type_: Any(
+                                            Any {
+                                                position: Position {
+                                                    path: "",
+                                                    line_number: 1,
+                                                    column_number: 1,
+                                                    line: "",
+                                                },
+                                            },
+                                        ),
+                                    },
+                                ],
+                                result_type: Boolean(
+                                    Boolean {
+                                        position: Position {
+                                            path: "",
+                                            line_number: 1,
+                                            column_number: 1,
+                                            line: "",
+                                        },
+                                    },
+                                ),
+                                body: Boolean(
+                                    Boolean {
+                                        value: false,
+                                        position: Position {
+                                            path: "",
+                                            line_number: 1,
+                                            column_number: 1,
+                                            line: "",
+                                        },
+                                    },
+                                ),
+                                position: Position {
+                                    path: "",
+                                    line_number: 1,
+                                    column_number: 1,
+                                    line: "",
+                                },
+                            },
+                        ),
+                        Lambda(
+                            Lambda {
+                                arguments: [
+                                    Argument {
+                                        name: "",
+                                        type_: Any(
+                                            Any {
+                                                position: Position {
+                                                    path: "",
+                                                    line_number: 1,
+                                                    column_number: 1,
+                                                    line: "",
+                                                },
+                                            },
+                                        ),
+                                    },
+                                ],
+                                result_type: Number(
+                                    Number {
+                                        position: Position {
+                                            path: "",
+                                            line_number: 1,
+                                            column_number: 1,
+                                            line: "",
+                                        },
+                                    },
+                                ),
+                                body: Number(
+                                    Number {
+                                        value: 0.0,
+                                        position: Position {
+                                            path: "",
+                                            line_number: 1,
+                                            column_number: 1,
+                                            line: "",
+                                        },
+                                    },
+                                ),
+                                position: Position {
+                                    path: "",
+                                    line_number: 1,
+                                    column_number: 1,
+                                    line: "",
+                                },
+                            },
+                        ),
+                    ],
                     position: Position {
                         path: "",
                         line_number: 1,
@@ -40,7 +538,52 @@ Ok(
                     },
                 },
             ),
-            arguments: [],
+            expression: Call(
+                Call {
+                    function_type: Some(
+                        Function(
+                            Function {
+                                arguments: [],
+                                result: Reference(
+                                    Reference {
+                                        name: "GenericMap",
+                                        position: Position {
+                                            path: "",
+                                            line_number: 1,
+                                            column_number: 1,
+                                            line: "",
+                                        },
+                                    },
+                                ),
+                                position: Position {
+                                    path: "",
+                                    line_number: 1,
+                                    column_number: 1,
+                                    line: "",
+                                },
+                            },
+                        ),
+                    ),
+                    function: Variable(
+                        Variable {
+                            name: "emptyMap",
+                            position: Position {
+                                path: "",
+                                line_number: 1,
+                                column_number: 1,
+                                line: "",
+                            },
+                        },
+                    ),
+                    arguments: [],
+                    position: Position {
+                        path: "",
+                        line_number: 1,
+                        column_number: 1,
+                        line: "",
+                    },
+                },
+            ),
             position: Position {
                 path: "",
                 line_number: 1,

--- a/lib/hir-mir/src/transformation/snapshots/hir_mir__transformation__map_literal__tests__transform_map_with_2_entries.snap
+++ b/lib/hir-mir/src/transformation/snapshots/hir_mir__transformation__map_literal__tests__transform_map_with_2_entries.snap
@@ -1,0 +1,1650 @@
+---
+source: lib/hir-mir/src/transformation/map_literal.rs
+expression: "transform(&CompileContext::dummy(Default::default(), Default::default()),\n    &Map::new(types::None::new(Position::fake()),\n            types::None::new(Position::fake()),\n            vec![MapEntry ::\n                new(Number :: new(1.0, Position :: fake()), None ::\n                new(Position :: fake()), Position :: fake()).into(), MapEntry\n                ::\n                new(Number :: new(2.0, Position :: fake()), None ::\n                new(Position :: fake()), Position :: fake()).into()],\n            Position::fake()))"
+---
+Ok(
+    Call(
+        Call {
+            function_type: Some(
+                Function(
+                    Function {
+                        arguments: [
+                            Reference(
+                                Reference {
+                                    name: "mapContext",
+                                    position: Position {
+                                        path: "",
+                                        line_number: 1,
+                                        column_number: 1,
+                                        line: "",
+                                    },
+                                },
+                            ),
+                            Reference(
+                                Reference {
+                                    name: "GenericMap",
+                                    position: Position {
+                                        path: "",
+                                        line_number: 1,
+                                        column_number: 1,
+                                        line: "",
+                                    },
+                                },
+                            ),
+                            Any(
+                                Any {
+                                    position: Position {
+                                        path: "",
+                                        line_number: 1,
+                                        column_number: 1,
+                                        line: "",
+                                    },
+                                },
+                            ),
+                            Any(
+                                Any {
+                                    position: Position {
+                                        path: "",
+                                        line_number: 1,
+                                        column_number: 1,
+                                        line: "",
+                                    },
+                                },
+                            ),
+                        ],
+                        result: Reference(
+                            Reference {
+                                name: "GenericMap",
+                                position: Position {
+                                    path: "",
+                                    line_number: 1,
+                                    column_number: 1,
+                                    line: "",
+                                },
+                            },
+                        ),
+                        position: Position {
+                            path: "",
+                            line_number: 1,
+                            column_number: 1,
+                            line: "",
+                        },
+                    },
+                ),
+            ),
+            function: Variable(
+                Variable {
+                    name: "setMap",
+                    position: Position {
+                        path: "",
+                        line_number: 1,
+                        column_number: 1,
+                        line: "",
+                    },
+                },
+            ),
+            arguments: [
+                Call(
+                    Call {
+                        function_type: Some(
+                            Function(
+                                Function {
+                                    arguments: [
+                                        Function(
+                                            Function {
+                                                arguments: [
+                                                    Any(
+                                                        Any {
+                                                            position: Position {
+                                                                path: "",
+                                                                line_number: 1,
+                                                                column_number: 1,
+                                                                line: "",
+                                                            },
+                                                        },
+                                                    ),
+                                                    Any(
+                                                        Any {
+                                                            position: Position {
+                                                                path: "",
+                                                                line_number: 1,
+                                                                column_number: 1,
+                                                                line: "",
+                                                            },
+                                                        },
+                                                    ),
+                                                ],
+                                                result: Boolean(
+                                                    Boolean {
+                                                        position: Position {
+                                                            path: "",
+                                                            line_number: 1,
+                                                            column_number: 1,
+                                                            line: "",
+                                                        },
+                                                    },
+                                                ),
+                                                position: Position {
+                                                    path: "",
+                                                    line_number: 1,
+                                                    column_number: 1,
+                                                    line: "",
+                                                },
+                                            },
+                                        ),
+                                        Function(
+                                            Function {
+                                                arguments: [
+                                                    Any(
+                                                        Any {
+                                                            position: Position {
+                                                                path: "",
+                                                                line_number: 1,
+                                                                column_number: 1,
+                                                                line: "",
+                                                            },
+                                                        },
+                                                    ),
+                                                ],
+                                                result: Number(
+                                                    Number {
+                                                        position: Position {
+                                                            path: "",
+                                                            line_number: 1,
+                                                            column_number: 1,
+                                                            line: "",
+                                                        },
+                                                    },
+                                                ),
+                                                position: Position {
+                                                    path: "",
+                                                    line_number: 1,
+                                                    column_number: 1,
+                                                    line: "",
+                                                },
+                                            },
+                                        ),
+                                        Function(
+                                            Function {
+                                                arguments: [
+                                                    Any(
+                                                        Any {
+                                                            position: Position {
+                                                                path: "",
+                                                                line_number: 1,
+                                                                column_number: 1,
+                                                                line: "",
+                                                            },
+                                                        },
+                                                    ),
+                                                    Any(
+                                                        Any {
+                                                            position: Position {
+                                                                path: "",
+                                                                line_number: 1,
+                                                                column_number: 1,
+                                                                line: "",
+                                                            },
+                                                        },
+                                                    ),
+                                                ],
+                                                result: Boolean(
+                                                    Boolean {
+                                                        position: Position {
+                                                            path: "",
+                                                            line_number: 1,
+                                                            column_number: 1,
+                                                            line: "",
+                                                        },
+                                                    },
+                                                ),
+                                                position: Position {
+                                                    path: "",
+                                                    line_number: 1,
+                                                    column_number: 1,
+                                                    line: "",
+                                                },
+                                            },
+                                        ),
+                                        Function(
+                                            Function {
+                                                arguments: [
+                                                    Any(
+                                                        Any {
+                                                            position: Position {
+                                                                path: "",
+                                                                line_number: 1,
+                                                                column_number: 1,
+                                                                line: "",
+                                                            },
+                                                        },
+                                                    ),
+                                                ],
+                                                result: Number(
+                                                    Number {
+                                                        position: Position {
+                                                            path: "",
+                                                            line_number: 1,
+                                                            column_number: 1,
+                                                            line: "",
+                                                        },
+                                                    },
+                                                ),
+                                                position: Position {
+                                                    path: "",
+                                                    line_number: 1,
+                                                    column_number: 1,
+                                                    line: "",
+                                                },
+                                            },
+                                        ),
+                                    ],
+                                    result: Reference(
+                                        Reference {
+                                            name: "mapContext",
+                                            position: Position {
+                                                path: "",
+                                                line_number: 1,
+                                                column_number: 1,
+                                                line: "",
+                                            },
+                                        },
+                                    ),
+                                    position: Position {
+                                        path: "",
+                                        line_number: 1,
+                                        column_number: 1,
+                                        line: "",
+                                    },
+                                },
+                            ),
+                        ),
+                        function: Variable(
+                            Variable {
+                                name: "newMapContext",
+                                position: Position {
+                                    path: "",
+                                    line_number: 1,
+                                    column_number: 1,
+                                    line: "",
+                                },
+                            },
+                        ),
+                        arguments: [
+                            Lambda(
+                                Lambda {
+                                    arguments: [
+                                        Argument {
+                                            name: "$lhs",
+                                            type_: Any(
+                                                Any {
+                                                    position: Position {
+                                                        path: "",
+                                                        line_number: 1,
+                                                        column_number: 1,
+                                                        line: "",
+                                                    },
+                                                },
+                                            ),
+                                        },
+                                        Argument {
+                                            name: "$rhs",
+                                            type_: Any(
+                                                Any {
+                                                    position: Position {
+                                                        path: "",
+                                                        line_number: 1,
+                                                        column_number: 1,
+                                                        line: "",
+                                                    },
+                                                },
+                                            ),
+                                        },
+                                    ],
+                                    result_type: Boolean(
+                                        Boolean {
+                                            position: Position {
+                                                path: "",
+                                                line_number: 1,
+                                                column_number: 1,
+                                                line: "",
+                                            },
+                                        },
+                                    ),
+                                    body: IfType(
+                                        IfType {
+                                            name: "$lhs",
+                                            argument: Variable(
+                                                Variable {
+                                                    name: "$lhs",
+                                                    position: Position {
+                                                        path: "",
+                                                        line_number: 1,
+                                                        column_number: 1,
+                                                        line: "",
+                                                    },
+                                                },
+                                            ),
+                                            branches: [
+                                                IfTypeBranch {
+                                                    type_: None(
+                                                        None {
+                                                            position: Position {
+                                                                path: "",
+                                                                line_number: 1,
+                                                                column_number: 1,
+                                                                line: "",
+                                                            },
+                                                        },
+                                                    ),
+                                                    expression: IfType(
+                                                        IfType {
+                                                            name: "$rhs",
+                                                            argument: Variable(
+                                                                Variable {
+                                                                    name: "$rhs",
+                                                                    position: Position {
+                                                                        path: "",
+                                                                        line_number: 1,
+                                                                        column_number: 1,
+                                                                        line: "",
+                                                                    },
+                                                                },
+                                                            ),
+                                                            branches: [
+                                                                IfTypeBranch {
+                                                                    type_: None(
+                                                                        None {
+                                                                            position: Position {
+                                                                                path: "",
+                                                                                line_number: 1,
+                                                                                column_number: 1,
+                                                                                line: "",
+                                                                            },
+                                                                        },
+                                                                    ),
+                                                                    expression: Boolean(
+                                                                        Boolean {
+                                                                            value: true,
+                                                                            position: Position {
+                                                                                path: "",
+                                                                                line_number: 1,
+                                                                                column_number: 1,
+                                                                                line: "",
+                                                                            },
+                                                                        },
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            else_: None,
+                                                            position: Position {
+                                                                path: "",
+                                                                line_number: 1,
+                                                                column_number: 1,
+                                                                line: "",
+                                                            },
+                                                        },
+                                                    ),
+                                                },
+                                            ],
+                                            else_: None,
+                                            position: Position {
+                                                path: "",
+                                                line_number: 1,
+                                                column_number: 1,
+                                                line: "",
+                                            },
+                                        },
+                                    ),
+                                    position: Position {
+                                        path: "",
+                                        line_number: 1,
+                                        column_number: 1,
+                                        line: "",
+                                    },
+                                },
+                            ),
+                            Lambda(
+                                Lambda {
+                                    arguments: [
+                                        Argument {
+                                            name: "$x",
+                                            type_: Any(
+                                                Any {
+                                                    position: Position {
+                                                        path: "",
+                                                        line_number: 1,
+                                                        column_number: 1,
+                                                        line: "",
+                                                    },
+                                                },
+                                            ),
+                                        },
+                                    ],
+                                    result_type: Number(
+                                        Number {
+                                            position: Position {
+                                                path: "",
+                                                line_number: 1,
+                                                column_number: 1,
+                                                line: "",
+                                            },
+                                        },
+                                    ),
+                                    body: IfType(
+                                        IfType {
+                                            name: "$x",
+                                            argument: Variable(
+                                                Variable {
+                                                    name: "$x",
+                                                    position: Position {
+                                                        path: "",
+                                                        line_number: 1,
+                                                        column_number: 1,
+                                                        line: "",
+                                                    },
+                                                },
+                                            ),
+                                            branches: [
+                                                IfTypeBranch {
+                                                    type_: None(
+                                                        None {
+                                                            position: Position {
+                                                                path: "",
+                                                                line_number: 1,
+                                                                column_number: 1,
+                                                                line: "",
+                                                            },
+                                                        },
+                                                    ),
+                                                    expression: Number(
+                                                        Number {
+                                                            value: 0.0,
+                                                            position: Position {
+                                                                path: "",
+                                                                line_number: 1,
+                                                                column_number: 1,
+                                                                line: "",
+                                                            },
+                                                        },
+                                                    ),
+                                                },
+                                            ],
+                                            else_: None,
+                                            position: Position {
+                                                path: "",
+                                                line_number: 1,
+                                                column_number: 1,
+                                                line: "",
+                                            },
+                                        },
+                                    ),
+                                    position: Position {
+                                        path: "",
+                                        line_number: 1,
+                                        column_number: 1,
+                                        line: "",
+                                    },
+                                },
+                            ),
+                            Lambda(
+                                Lambda {
+                                    arguments: [
+                                        Argument {
+                                            name: "$lhs",
+                                            type_: Any(
+                                                Any {
+                                                    position: Position {
+                                                        path: "",
+                                                        line_number: 1,
+                                                        column_number: 1,
+                                                        line: "",
+                                                    },
+                                                },
+                                            ),
+                                        },
+                                        Argument {
+                                            name: "$rhs",
+                                            type_: Any(
+                                                Any {
+                                                    position: Position {
+                                                        path: "",
+                                                        line_number: 1,
+                                                        column_number: 1,
+                                                        line: "",
+                                                    },
+                                                },
+                                            ),
+                                        },
+                                    ],
+                                    result_type: Boolean(
+                                        Boolean {
+                                            position: Position {
+                                                path: "",
+                                                line_number: 1,
+                                                column_number: 1,
+                                                line: "",
+                                            },
+                                        },
+                                    ),
+                                    body: IfType(
+                                        IfType {
+                                            name: "$lhs",
+                                            argument: Variable(
+                                                Variable {
+                                                    name: "$lhs",
+                                                    position: Position {
+                                                        path: "",
+                                                        line_number: 1,
+                                                        column_number: 1,
+                                                        line: "",
+                                                    },
+                                                },
+                                            ),
+                                            branches: [
+                                                IfTypeBranch {
+                                                    type_: None(
+                                                        None {
+                                                            position: Position {
+                                                                path: "",
+                                                                line_number: 1,
+                                                                column_number: 1,
+                                                                line: "",
+                                                            },
+                                                        },
+                                                    ),
+                                                    expression: IfType(
+                                                        IfType {
+                                                            name: "$rhs",
+                                                            argument: Variable(
+                                                                Variable {
+                                                                    name: "$rhs",
+                                                                    position: Position {
+                                                                        path: "",
+                                                                        line_number: 1,
+                                                                        column_number: 1,
+                                                                        line: "",
+                                                                    },
+                                                                },
+                                                            ),
+                                                            branches: [
+                                                                IfTypeBranch {
+                                                                    type_: None(
+                                                                        None {
+                                                                            position: Position {
+                                                                                path: "",
+                                                                                line_number: 1,
+                                                                                column_number: 1,
+                                                                                line: "",
+                                                                            },
+                                                                        },
+                                                                    ),
+                                                                    expression: Boolean(
+                                                                        Boolean {
+                                                                            value: true,
+                                                                            position: Position {
+                                                                                path: "",
+                                                                                line_number: 1,
+                                                                                column_number: 1,
+                                                                                line: "",
+                                                                            },
+                                                                        },
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            else_: None,
+                                                            position: Position {
+                                                                path: "",
+                                                                line_number: 1,
+                                                                column_number: 1,
+                                                                line: "",
+                                                            },
+                                                        },
+                                                    ),
+                                                },
+                                            ],
+                                            else_: None,
+                                            position: Position {
+                                                path: "",
+                                                line_number: 1,
+                                                column_number: 1,
+                                                line: "",
+                                            },
+                                        },
+                                    ),
+                                    position: Position {
+                                        path: "",
+                                        line_number: 1,
+                                        column_number: 1,
+                                        line: "",
+                                    },
+                                },
+                            ),
+                            Lambda(
+                                Lambda {
+                                    arguments: [
+                                        Argument {
+                                            name: "$x",
+                                            type_: Any(
+                                                Any {
+                                                    position: Position {
+                                                        path: "",
+                                                        line_number: 1,
+                                                        column_number: 1,
+                                                        line: "",
+                                                    },
+                                                },
+                                            ),
+                                        },
+                                    ],
+                                    result_type: Number(
+                                        Number {
+                                            position: Position {
+                                                path: "",
+                                                line_number: 1,
+                                                column_number: 1,
+                                                line: "",
+                                            },
+                                        },
+                                    ),
+                                    body: IfType(
+                                        IfType {
+                                            name: "$x",
+                                            argument: Variable(
+                                                Variable {
+                                                    name: "$x",
+                                                    position: Position {
+                                                        path: "",
+                                                        line_number: 1,
+                                                        column_number: 1,
+                                                        line: "",
+                                                    },
+                                                },
+                                            ),
+                                            branches: [
+                                                IfTypeBranch {
+                                                    type_: None(
+                                                        None {
+                                                            position: Position {
+                                                                path: "",
+                                                                line_number: 1,
+                                                                column_number: 1,
+                                                                line: "",
+                                                            },
+                                                        },
+                                                    ),
+                                                    expression: Number(
+                                                        Number {
+                                                            value: 0.0,
+                                                            position: Position {
+                                                                path: "",
+                                                                line_number: 1,
+                                                                column_number: 1,
+                                                                line: "",
+                                                            },
+                                                        },
+                                                    ),
+                                                },
+                                            ],
+                                            else_: None,
+                                            position: Position {
+                                                path: "",
+                                                line_number: 1,
+                                                column_number: 1,
+                                                line: "",
+                                            },
+                                        },
+                                    ),
+                                    position: Position {
+                                        path: "",
+                                        line_number: 1,
+                                        column_number: 1,
+                                        line: "",
+                                    },
+                                },
+                            ),
+                        ],
+                        position: Position {
+                            path: "",
+                            line_number: 1,
+                            column_number: 1,
+                            line: "",
+                        },
+                    },
+                ),
+                Call(
+                    Call {
+                        function_type: Some(
+                            Function(
+                                Function {
+                                    arguments: [
+                                        Reference(
+                                            Reference {
+                                                name: "mapContext",
+                                                position: Position {
+                                                    path: "",
+                                                    line_number: 1,
+                                                    column_number: 1,
+                                                    line: "",
+                                                },
+                                            },
+                                        ),
+                                        Reference(
+                                            Reference {
+                                                name: "GenericMap",
+                                                position: Position {
+                                                    path: "",
+                                                    line_number: 1,
+                                                    column_number: 1,
+                                                    line: "",
+                                                },
+                                            },
+                                        ),
+                                        Any(
+                                            Any {
+                                                position: Position {
+                                                    path: "",
+                                                    line_number: 1,
+                                                    column_number: 1,
+                                                    line: "",
+                                                },
+                                            },
+                                        ),
+                                        Any(
+                                            Any {
+                                                position: Position {
+                                                    path: "",
+                                                    line_number: 1,
+                                                    column_number: 1,
+                                                    line: "",
+                                                },
+                                            },
+                                        ),
+                                    ],
+                                    result: Reference(
+                                        Reference {
+                                            name: "GenericMap",
+                                            position: Position {
+                                                path: "",
+                                                line_number: 1,
+                                                column_number: 1,
+                                                line: "",
+                                            },
+                                        },
+                                    ),
+                                    position: Position {
+                                        path: "",
+                                        line_number: 1,
+                                        column_number: 1,
+                                        line: "",
+                                    },
+                                },
+                            ),
+                        ),
+                        function: Variable(
+                            Variable {
+                                name: "setMap",
+                                position: Position {
+                                    path: "",
+                                    line_number: 1,
+                                    column_number: 1,
+                                    line: "",
+                                },
+                            },
+                        ),
+                        arguments: [
+                            Call(
+                                Call {
+                                    function_type: Some(
+                                        Function(
+                                            Function {
+                                                arguments: [
+                                                    Function(
+                                                        Function {
+                                                            arguments: [
+                                                                Any(
+                                                                    Any {
+                                                                        position: Position {
+                                                                            path: "",
+                                                                            line_number: 1,
+                                                                            column_number: 1,
+                                                                            line: "",
+                                                                        },
+                                                                    },
+                                                                ),
+                                                                Any(
+                                                                    Any {
+                                                                        position: Position {
+                                                                            path: "",
+                                                                            line_number: 1,
+                                                                            column_number: 1,
+                                                                            line: "",
+                                                                        },
+                                                                    },
+                                                                ),
+                                                            ],
+                                                            result: Boolean(
+                                                                Boolean {
+                                                                    position: Position {
+                                                                        path: "",
+                                                                        line_number: 1,
+                                                                        column_number: 1,
+                                                                        line: "",
+                                                                    },
+                                                                },
+                                                            ),
+                                                            position: Position {
+                                                                path: "",
+                                                                line_number: 1,
+                                                                column_number: 1,
+                                                                line: "",
+                                                            },
+                                                        },
+                                                    ),
+                                                    Function(
+                                                        Function {
+                                                            arguments: [
+                                                                Any(
+                                                                    Any {
+                                                                        position: Position {
+                                                                            path: "",
+                                                                            line_number: 1,
+                                                                            column_number: 1,
+                                                                            line: "",
+                                                                        },
+                                                                    },
+                                                                ),
+                                                            ],
+                                                            result: Number(
+                                                                Number {
+                                                                    position: Position {
+                                                                        path: "",
+                                                                        line_number: 1,
+                                                                        column_number: 1,
+                                                                        line: "",
+                                                                    },
+                                                                },
+                                                            ),
+                                                            position: Position {
+                                                                path: "",
+                                                                line_number: 1,
+                                                                column_number: 1,
+                                                                line: "",
+                                                            },
+                                                        },
+                                                    ),
+                                                    Function(
+                                                        Function {
+                                                            arguments: [
+                                                                Any(
+                                                                    Any {
+                                                                        position: Position {
+                                                                            path: "",
+                                                                            line_number: 1,
+                                                                            column_number: 1,
+                                                                            line: "",
+                                                                        },
+                                                                    },
+                                                                ),
+                                                                Any(
+                                                                    Any {
+                                                                        position: Position {
+                                                                            path: "",
+                                                                            line_number: 1,
+                                                                            column_number: 1,
+                                                                            line: "",
+                                                                        },
+                                                                    },
+                                                                ),
+                                                            ],
+                                                            result: Boolean(
+                                                                Boolean {
+                                                                    position: Position {
+                                                                        path: "",
+                                                                        line_number: 1,
+                                                                        column_number: 1,
+                                                                        line: "",
+                                                                    },
+                                                                },
+                                                            ),
+                                                            position: Position {
+                                                                path: "",
+                                                                line_number: 1,
+                                                                column_number: 1,
+                                                                line: "",
+                                                            },
+                                                        },
+                                                    ),
+                                                    Function(
+                                                        Function {
+                                                            arguments: [
+                                                                Any(
+                                                                    Any {
+                                                                        position: Position {
+                                                                            path: "",
+                                                                            line_number: 1,
+                                                                            column_number: 1,
+                                                                            line: "",
+                                                                        },
+                                                                    },
+                                                                ),
+                                                            ],
+                                                            result: Number(
+                                                                Number {
+                                                                    position: Position {
+                                                                        path: "",
+                                                                        line_number: 1,
+                                                                        column_number: 1,
+                                                                        line: "",
+                                                                    },
+                                                                },
+                                                            ),
+                                                            position: Position {
+                                                                path: "",
+                                                                line_number: 1,
+                                                                column_number: 1,
+                                                                line: "",
+                                                            },
+                                                        },
+                                                    ),
+                                                ],
+                                                result: Reference(
+                                                    Reference {
+                                                        name: "mapContext",
+                                                        position: Position {
+                                                            path: "",
+                                                            line_number: 1,
+                                                            column_number: 1,
+                                                            line: "",
+                                                        },
+                                                    },
+                                                ),
+                                                position: Position {
+                                                    path: "",
+                                                    line_number: 1,
+                                                    column_number: 1,
+                                                    line: "",
+                                                },
+                                            },
+                                        ),
+                                    ),
+                                    function: Variable(
+                                        Variable {
+                                            name: "newMapContext",
+                                            position: Position {
+                                                path: "",
+                                                line_number: 1,
+                                                column_number: 1,
+                                                line: "",
+                                            },
+                                        },
+                                    ),
+                                    arguments: [
+                                        Lambda(
+                                            Lambda {
+                                                arguments: [
+                                                    Argument {
+                                                        name: "$lhs",
+                                                        type_: Any(
+                                                            Any {
+                                                                position: Position {
+                                                                    path: "",
+                                                                    line_number: 1,
+                                                                    column_number: 1,
+                                                                    line: "",
+                                                                },
+                                                            },
+                                                        ),
+                                                    },
+                                                    Argument {
+                                                        name: "$rhs",
+                                                        type_: Any(
+                                                            Any {
+                                                                position: Position {
+                                                                    path: "",
+                                                                    line_number: 1,
+                                                                    column_number: 1,
+                                                                    line: "",
+                                                                },
+                                                            },
+                                                        ),
+                                                    },
+                                                ],
+                                                result_type: Boolean(
+                                                    Boolean {
+                                                        position: Position {
+                                                            path: "",
+                                                            line_number: 1,
+                                                            column_number: 1,
+                                                            line: "",
+                                                        },
+                                                    },
+                                                ),
+                                                body: IfType(
+                                                    IfType {
+                                                        name: "$lhs",
+                                                        argument: Variable(
+                                                            Variable {
+                                                                name: "$lhs",
+                                                                position: Position {
+                                                                    path: "",
+                                                                    line_number: 1,
+                                                                    column_number: 1,
+                                                                    line: "",
+                                                                },
+                                                            },
+                                                        ),
+                                                        branches: [
+                                                            IfTypeBranch {
+                                                                type_: None(
+                                                                    None {
+                                                                        position: Position {
+                                                                            path: "",
+                                                                            line_number: 1,
+                                                                            column_number: 1,
+                                                                            line: "",
+                                                                        },
+                                                                    },
+                                                                ),
+                                                                expression: IfType(
+                                                                    IfType {
+                                                                        name: "$rhs",
+                                                                        argument: Variable(
+                                                                            Variable {
+                                                                                name: "$rhs",
+                                                                                position: Position {
+                                                                                    path: "",
+                                                                                    line_number: 1,
+                                                                                    column_number: 1,
+                                                                                    line: "",
+                                                                                },
+                                                                            },
+                                                                        ),
+                                                                        branches: [
+                                                                            IfTypeBranch {
+                                                                                type_: None(
+                                                                                    None {
+                                                                                        position: Position {
+                                                                                            path: "",
+                                                                                            line_number: 1,
+                                                                                            column_number: 1,
+                                                                                            line: "",
+                                                                                        },
+                                                                                    },
+                                                                                ),
+                                                                                expression: Boolean(
+                                                                                    Boolean {
+                                                                                        value: true,
+                                                                                        position: Position {
+                                                                                            path: "",
+                                                                                            line_number: 1,
+                                                                                            column_number: 1,
+                                                                                            line: "",
+                                                                                        },
+                                                                                    },
+                                                                                ),
+                                                                            },
+                                                                        ],
+                                                                        else_: None,
+                                                                        position: Position {
+                                                                            path: "",
+                                                                            line_number: 1,
+                                                                            column_number: 1,
+                                                                            line: "",
+                                                                        },
+                                                                    },
+                                                                ),
+                                                            },
+                                                        ],
+                                                        else_: None,
+                                                        position: Position {
+                                                            path: "",
+                                                            line_number: 1,
+                                                            column_number: 1,
+                                                            line: "",
+                                                        },
+                                                    },
+                                                ),
+                                                position: Position {
+                                                    path: "",
+                                                    line_number: 1,
+                                                    column_number: 1,
+                                                    line: "",
+                                                },
+                                            },
+                                        ),
+                                        Lambda(
+                                            Lambda {
+                                                arguments: [
+                                                    Argument {
+                                                        name: "$x",
+                                                        type_: Any(
+                                                            Any {
+                                                                position: Position {
+                                                                    path: "",
+                                                                    line_number: 1,
+                                                                    column_number: 1,
+                                                                    line: "",
+                                                                },
+                                                            },
+                                                        ),
+                                                    },
+                                                ],
+                                                result_type: Number(
+                                                    Number {
+                                                        position: Position {
+                                                            path: "",
+                                                            line_number: 1,
+                                                            column_number: 1,
+                                                            line: "",
+                                                        },
+                                                    },
+                                                ),
+                                                body: IfType(
+                                                    IfType {
+                                                        name: "$x",
+                                                        argument: Variable(
+                                                            Variable {
+                                                                name: "$x",
+                                                                position: Position {
+                                                                    path: "",
+                                                                    line_number: 1,
+                                                                    column_number: 1,
+                                                                    line: "",
+                                                                },
+                                                            },
+                                                        ),
+                                                        branches: [
+                                                            IfTypeBranch {
+                                                                type_: None(
+                                                                    None {
+                                                                        position: Position {
+                                                                            path: "",
+                                                                            line_number: 1,
+                                                                            column_number: 1,
+                                                                            line: "",
+                                                                        },
+                                                                    },
+                                                                ),
+                                                                expression: Number(
+                                                                    Number {
+                                                                        value: 0.0,
+                                                                        position: Position {
+                                                                            path: "",
+                                                                            line_number: 1,
+                                                                            column_number: 1,
+                                                                            line: "",
+                                                                        },
+                                                                    },
+                                                                ),
+                                                            },
+                                                        ],
+                                                        else_: None,
+                                                        position: Position {
+                                                            path: "",
+                                                            line_number: 1,
+                                                            column_number: 1,
+                                                            line: "",
+                                                        },
+                                                    },
+                                                ),
+                                                position: Position {
+                                                    path: "",
+                                                    line_number: 1,
+                                                    column_number: 1,
+                                                    line: "",
+                                                },
+                                            },
+                                        ),
+                                        Lambda(
+                                            Lambda {
+                                                arguments: [
+                                                    Argument {
+                                                        name: "$lhs",
+                                                        type_: Any(
+                                                            Any {
+                                                                position: Position {
+                                                                    path: "",
+                                                                    line_number: 1,
+                                                                    column_number: 1,
+                                                                    line: "",
+                                                                },
+                                                            },
+                                                        ),
+                                                    },
+                                                    Argument {
+                                                        name: "$rhs",
+                                                        type_: Any(
+                                                            Any {
+                                                                position: Position {
+                                                                    path: "",
+                                                                    line_number: 1,
+                                                                    column_number: 1,
+                                                                    line: "",
+                                                                },
+                                                            },
+                                                        ),
+                                                    },
+                                                ],
+                                                result_type: Boolean(
+                                                    Boolean {
+                                                        position: Position {
+                                                            path: "",
+                                                            line_number: 1,
+                                                            column_number: 1,
+                                                            line: "",
+                                                        },
+                                                    },
+                                                ),
+                                                body: IfType(
+                                                    IfType {
+                                                        name: "$lhs",
+                                                        argument: Variable(
+                                                            Variable {
+                                                                name: "$lhs",
+                                                                position: Position {
+                                                                    path: "",
+                                                                    line_number: 1,
+                                                                    column_number: 1,
+                                                                    line: "",
+                                                                },
+                                                            },
+                                                        ),
+                                                        branches: [
+                                                            IfTypeBranch {
+                                                                type_: None(
+                                                                    None {
+                                                                        position: Position {
+                                                                            path: "",
+                                                                            line_number: 1,
+                                                                            column_number: 1,
+                                                                            line: "",
+                                                                        },
+                                                                    },
+                                                                ),
+                                                                expression: IfType(
+                                                                    IfType {
+                                                                        name: "$rhs",
+                                                                        argument: Variable(
+                                                                            Variable {
+                                                                                name: "$rhs",
+                                                                                position: Position {
+                                                                                    path: "",
+                                                                                    line_number: 1,
+                                                                                    column_number: 1,
+                                                                                    line: "",
+                                                                                },
+                                                                            },
+                                                                        ),
+                                                                        branches: [
+                                                                            IfTypeBranch {
+                                                                                type_: None(
+                                                                                    None {
+                                                                                        position: Position {
+                                                                                            path: "",
+                                                                                            line_number: 1,
+                                                                                            column_number: 1,
+                                                                                            line: "",
+                                                                                        },
+                                                                                    },
+                                                                                ),
+                                                                                expression: Boolean(
+                                                                                    Boolean {
+                                                                                        value: true,
+                                                                                        position: Position {
+                                                                                            path: "",
+                                                                                            line_number: 1,
+                                                                                            column_number: 1,
+                                                                                            line: "",
+                                                                                        },
+                                                                                    },
+                                                                                ),
+                                                                            },
+                                                                        ],
+                                                                        else_: None,
+                                                                        position: Position {
+                                                                            path: "",
+                                                                            line_number: 1,
+                                                                            column_number: 1,
+                                                                            line: "",
+                                                                        },
+                                                                    },
+                                                                ),
+                                                            },
+                                                        ],
+                                                        else_: None,
+                                                        position: Position {
+                                                            path: "",
+                                                            line_number: 1,
+                                                            column_number: 1,
+                                                            line: "",
+                                                        },
+                                                    },
+                                                ),
+                                                position: Position {
+                                                    path: "",
+                                                    line_number: 1,
+                                                    column_number: 1,
+                                                    line: "",
+                                                },
+                                            },
+                                        ),
+                                        Lambda(
+                                            Lambda {
+                                                arguments: [
+                                                    Argument {
+                                                        name: "$x",
+                                                        type_: Any(
+                                                            Any {
+                                                                position: Position {
+                                                                    path: "",
+                                                                    line_number: 1,
+                                                                    column_number: 1,
+                                                                    line: "",
+                                                                },
+                                                            },
+                                                        ),
+                                                    },
+                                                ],
+                                                result_type: Number(
+                                                    Number {
+                                                        position: Position {
+                                                            path: "",
+                                                            line_number: 1,
+                                                            column_number: 1,
+                                                            line: "",
+                                                        },
+                                                    },
+                                                ),
+                                                body: IfType(
+                                                    IfType {
+                                                        name: "$x",
+                                                        argument: Variable(
+                                                            Variable {
+                                                                name: "$x",
+                                                                position: Position {
+                                                                    path: "",
+                                                                    line_number: 1,
+                                                                    column_number: 1,
+                                                                    line: "",
+                                                                },
+                                                            },
+                                                        ),
+                                                        branches: [
+                                                            IfTypeBranch {
+                                                                type_: None(
+                                                                    None {
+                                                                        position: Position {
+                                                                            path: "",
+                                                                            line_number: 1,
+                                                                            column_number: 1,
+                                                                            line: "",
+                                                                        },
+                                                                    },
+                                                                ),
+                                                                expression: Number(
+                                                                    Number {
+                                                                        value: 0.0,
+                                                                        position: Position {
+                                                                            path: "",
+                                                                            line_number: 1,
+                                                                            column_number: 1,
+                                                                            line: "",
+                                                                        },
+                                                                    },
+                                                                ),
+                                                            },
+                                                        ],
+                                                        else_: None,
+                                                        position: Position {
+                                                            path: "",
+                                                            line_number: 1,
+                                                            column_number: 1,
+                                                            line: "",
+                                                        },
+                                                    },
+                                                ),
+                                                position: Position {
+                                                    path: "",
+                                                    line_number: 1,
+                                                    column_number: 1,
+                                                    line: "",
+                                                },
+                                            },
+                                        ),
+                                    ],
+                                    position: Position {
+                                        path: "",
+                                        line_number: 1,
+                                        column_number: 1,
+                                        line: "",
+                                    },
+                                },
+                            ),
+                            Call(
+                                Call {
+                                    function_type: Some(
+                                        Function(
+                                            Function {
+                                                arguments: [],
+                                                result: Reference(
+                                                    Reference {
+                                                        name: "GenericMap",
+                                                        position: Position {
+                                                            path: "",
+                                                            line_number: 1,
+                                                            column_number: 1,
+                                                            line: "",
+                                                        },
+                                                    },
+                                                ),
+                                                position: Position {
+                                                    path: "",
+                                                    line_number: 1,
+                                                    column_number: 1,
+                                                    line: "",
+                                                },
+                                            },
+                                        ),
+                                    ),
+                                    function: Variable(
+                                        Variable {
+                                            name: "emptyMap",
+                                            position: Position {
+                                                path: "",
+                                                line_number: 1,
+                                                column_number: 1,
+                                                line: "",
+                                            },
+                                        },
+                                    ),
+                                    arguments: [],
+                                    position: Position {
+                                        path: "",
+                                        line_number: 1,
+                                        column_number: 1,
+                                        line: "",
+                                    },
+                                },
+                            ),
+                            TypeCoercion(
+                                TypeCoercion {
+                                    from: None(
+                                        None {
+                                            position: Position {
+                                                path: "",
+                                                line_number: 1,
+                                                column_number: 1,
+                                                line: "",
+                                            },
+                                        },
+                                    ),
+                                    to: Any(
+                                        Any {
+                                            position: Position {
+                                                path: "",
+                                                line_number: 1,
+                                                column_number: 1,
+                                                line: "",
+                                            },
+                                        },
+                                    ),
+                                    argument: Number(
+                                        Number {
+                                            value: 1.0,
+                                            position: Position {
+                                                path: "",
+                                                line_number: 1,
+                                                column_number: 1,
+                                                line: "",
+                                            },
+                                        },
+                                    ),
+                                    position: Position {
+                                        path: "",
+                                        line_number: 1,
+                                        column_number: 1,
+                                        line: "",
+                                    },
+                                },
+                            ),
+                            TypeCoercion(
+                                TypeCoercion {
+                                    from: None(
+                                        None {
+                                            position: Position {
+                                                path: "",
+                                                line_number: 1,
+                                                column_number: 1,
+                                                line: "",
+                                            },
+                                        },
+                                    ),
+                                    to: Any(
+                                        Any {
+                                            position: Position {
+                                                path: "",
+                                                line_number: 1,
+                                                column_number: 1,
+                                                line: "",
+                                            },
+                                        },
+                                    ),
+                                    argument: None(
+                                        None {
+                                            position: Position {
+                                                path: "",
+                                                line_number: 1,
+                                                column_number: 1,
+                                                line: "",
+                                            },
+                                        },
+                                    ),
+                                    position: Position {
+                                        path: "",
+                                        line_number: 1,
+                                        column_number: 1,
+                                        line: "",
+                                    },
+                                },
+                            ),
+                        ],
+                        position: Position {
+                            path: "",
+                            line_number: 1,
+                            column_number: 1,
+                            line: "",
+                        },
+                    },
+                ),
+                TypeCoercion(
+                    TypeCoercion {
+                        from: None(
+                            None {
+                                position: Position {
+                                    path: "",
+                                    line_number: 1,
+                                    column_number: 1,
+                                    line: "",
+                                },
+                            },
+                        ),
+                        to: Any(
+                            Any {
+                                position: Position {
+                                    path: "",
+                                    line_number: 1,
+                                    column_number: 1,
+                                    line: "",
+                                },
+                            },
+                        ),
+                        argument: Number(
+                            Number {
+                                value: 2.0,
+                                position: Position {
+                                    path: "",
+                                    line_number: 1,
+                                    column_number: 1,
+                                    line: "",
+                                },
+                            },
+                        ),
+                        position: Position {
+                            path: "",
+                            line_number: 1,
+                            column_number: 1,
+                            line: "",
+                        },
+                    },
+                ),
+                TypeCoercion(
+                    TypeCoercion {
+                        from: None(
+                            None {
+                                position: Position {
+                                    path: "",
+                                    line_number: 1,
+                                    column_number: 1,
+                                    line: "",
+                                },
+                            },
+                        ),
+                        to: Any(
+                            Any {
+                                position: Position {
+                                    path: "",
+                                    line_number: 1,
+                                    column_number: 1,
+                                    line: "",
+                                },
+                            },
+                        ),
+                        argument: None(
+                            None {
+                                position: Position {
+                                    path: "",
+                                    line_number: 1,
+                                    column_number: 1,
+                                    line: "",
+                                },
+                            },
+                        ),
+                        position: Position {
+                            path: "",
+                            line_number: 1,
+                            column_number: 1,
+                            line: "",
+                        },
+                    },
+                ),
+            ],
+            position: Position {
+                path: "",
+                line_number: 1,
+                column_number: 1,
+                line: "",
+            },
+        },
+    ),
+)

--- a/lib/hir-mir/src/transformation/snapshots/hir_mir__transformation__map_literal__tests__transform_map_with_2_entries.snap
+++ b/lib/hir-mir/src/transformation/snapshots/hir_mir__transformation__map_literal__tests__transform_map_with_2_entries.snap
@@ -3,66 +3,15 @@ source: lib/hir-mir/src/transformation/map_literal.rs
 expression: "transform(&CompileContext::dummy(Default::default(), Default::default()),\n    &Map::new(types::None::new(Position::fake()),\n            types::None::new(Position::fake()),\n            vec![MapEntry ::\n                new(Number :: new(1.0, Position :: fake()), None ::\n                new(Position :: fake()), Position :: fake()).into(), MapEntry\n                ::\n                new(Number :: new(2.0, Position :: fake()), None ::\n                new(Position :: fake()), Position :: fake()).into()],\n            Position::fake()))"
 ---
 Ok(
-    Call(
-        Call {
-            function_type: Some(
-                Function(
-                    Function {
-                        arguments: [
-                            Reference(
-                                Reference {
-                                    name: "mapContext",
-                                    position: Position {
-                                        path: "",
-                                        line_number: 1,
-                                        column_number: 1,
-                                        line: "",
-                                    },
-                                },
-                            ),
-                            Reference(
-                                Reference {
-                                    name: "GenericMap",
-                                    position: Position {
-                                        path: "",
-                                        line_number: 1,
-                                        column_number: 1,
-                                        line: "",
-                                    },
-                                },
-                            ),
-                            Any(
-                                Any {
-                                    position: Position {
-                                        path: "",
-                                        line_number: 1,
-                                        column_number: 1,
-                                        line: "",
-                                    },
-                                },
-                            ),
-                            Any(
-                                Any {
-                                    position: Position {
-                                        path: "",
-                                        line_number: 1,
-                                        column_number: 1,
-                                        line: "",
-                                    },
-                                },
-                            ),
-                        ],
-                        result: Reference(
-                            Reference {
-                                name: "GenericMap",
-                                position: Position {
-                                    path: "",
-                                    line_number: 1,
-                                    column_number: 1,
-                                    line: "",
-                                },
-                            },
-                        ),
+    Let(
+        Let {
+            name: Some(
+                "$ctx",
+            ),
+            type_: Some(
+                Reference(
+                    Reference {
+                        name: "mapContext",
                         position: Position {
                             path: "",
                             line_number: 1,
@@ -72,9 +21,626 @@ Ok(
                     },
                 ),
             ),
-            function: Variable(
-                Variable {
-                    name: "setMap",
+            bound_expression: Call(
+                Call {
+                    function_type: Some(
+                        Function(
+                            Function {
+                                arguments: [
+                                    Function(
+                                        Function {
+                                            arguments: [
+                                                Any(
+                                                    Any {
+                                                        position: Position {
+                                                            path: "",
+                                                            line_number: 1,
+                                                            column_number: 1,
+                                                            line: "",
+                                                        },
+                                                    },
+                                                ),
+                                                Any(
+                                                    Any {
+                                                        position: Position {
+                                                            path: "",
+                                                            line_number: 1,
+                                                            column_number: 1,
+                                                            line: "",
+                                                        },
+                                                    },
+                                                ),
+                                            ],
+                                            result: Boolean(
+                                                Boolean {
+                                                    position: Position {
+                                                        path: "",
+                                                        line_number: 1,
+                                                        column_number: 1,
+                                                        line: "",
+                                                    },
+                                                },
+                                            ),
+                                            position: Position {
+                                                path: "",
+                                                line_number: 1,
+                                                column_number: 1,
+                                                line: "",
+                                            },
+                                        },
+                                    ),
+                                    Function(
+                                        Function {
+                                            arguments: [
+                                                Any(
+                                                    Any {
+                                                        position: Position {
+                                                            path: "",
+                                                            line_number: 1,
+                                                            column_number: 1,
+                                                            line: "",
+                                                        },
+                                                    },
+                                                ),
+                                            ],
+                                            result: Number(
+                                                Number {
+                                                    position: Position {
+                                                        path: "",
+                                                        line_number: 1,
+                                                        column_number: 1,
+                                                        line: "",
+                                                    },
+                                                },
+                                            ),
+                                            position: Position {
+                                                path: "",
+                                                line_number: 1,
+                                                column_number: 1,
+                                                line: "",
+                                            },
+                                        },
+                                    ),
+                                    Function(
+                                        Function {
+                                            arguments: [
+                                                Any(
+                                                    Any {
+                                                        position: Position {
+                                                            path: "",
+                                                            line_number: 1,
+                                                            column_number: 1,
+                                                            line: "",
+                                                        },
+                                                    },
+                                                ),
+                                                Any(
+                                                    Any {
+                                                        position: Position {
+                                                            path: "",
+                                                            line_number: 1,
+                                                            column_number: 1,
+                                                            line: "",
+                                                        },
+                                                    },
+                                                ),
+                                            ],
+                                            result: Boolean(
+                                                Boolean {
+                                                    position: Position {
+                                                        path: "",
+                                                        line_number: 1,
+                                                        column_number: 1,
+                                                        line: "",
+                                                    },
+                                                },
+                                            ),
+                                            position: Position {
+                                                path: "",
+                                                line_number: 1,
+                                                column_number: 1,
+                                                line: "",
+                                            },
+                                        },
+                                    ),
+                                    Function(
+                                        Function {
+                                            arguments: [
+                                                Any(
+                                                    Any {
+                                                        position: Position {
+                                                            path: "",
+                                                            line_number: 1,
+                                                            column_number: 1,
+                                                            line: "",
+                                                        },
+                                                    },
+                                                ),
+                                            ],
+                                            result: Number(
+                                                Number {
+                                                    position: Position {
+                                                        path: "",
+                                                        line_number: 1,
+                                                        column_number: 1,
+                                                        line: "",
+                                                    },
+                                                },
+                                            ),
+                                            position: Position {
+                                                path: "",
+                                                line_number: 1,
+                                                column_number: 1,
+                                                line: "",
+                                            },
+                                        },
+                                    ),
+                                ],
+                                result: Reference(
+                                    Reference {
+                                        name: "mapContext",
+                                        position: Position {
+                                            path: "",
+                                            line_number: 1,
+                                            column_number: 1,
+                                            line: "",
+                                        },
+                                    },
+                                ),
+                                position: Position {
+                                    path: "",
+                                    line_number: 1,
+                                    column_number: 1,
+                                    line: "",
+                                },
+                            },
+                        ),
+                    ),
+                    function: Variable(
+                        Variable {
+                            name: "newMapContext",
+                            position: Position {
+                                path: "",
+                                line_number: 1,
+                                column_number: 1,
+                                line: "",
+                            },
+                        },
+                    ),
+                    arguments: [
+                        Lambda(
+                            Lambda {
+                                arguments: [
+                                    Argument {
+                                        name: "$lhs",
+                                        type_: Any(
+                                            Any {
+                                                position: Position {
+                                                    path: "",
+                                                    line_number: 1,
+                                                    column_number: 1,
+                                                    line: "",
+                                                },
+                                            },
+                                        ),
+                                    },
+                                    Argument {
+                                        name: "$rhs",
+                                        type_: Any(
+                                            Any {
+                                                position: Position {
+                                                    path: "",
+                                                    line_number: 1,
+                                                    column_number: 1,
+                                                    line: "",
+                                                },
+                                            },
+                                        ),
+                                    },
+                                ],
+                                result_type: Boolean(
+                                    Boolean {
+                                        position: Position {
+                                            path: "",
+                                            line_number: 1,
+                                            column_number: 1,
+                                            line: "",
+                                        },
+                                    },
+                                ),
+                                body: IfType(
+                                    IfType {
+                                        name: "$lhs",
+                                        argument: Variable(
+                                            Variable {
+                                                name: "$lhs",
+                                                position: Position {
+                                                    path: "",
+                                                    line_number: 1,
+                                                    column_number: 1,
+                                                    line: "",
+                                                },
+                                            },
+                                        ),
+                                        branches: [
+                                            IfTypeBranch {
+                                                type_: None(
+                                                    None {
+                                                        position: Position {
+                                                            path: "",
+                                                            line_number: 1,
+                                                            column_number: 1,
+                                                            line: "",
+                                                        },
+                                                    },
+                                                ),
+                                                expression: IfType(
+                                                    IfType {
+                                                        name: "$rhs",
+                                                        argument: Variable(
+                                                            Variable {
+                                                                name: "$rhs",
+                                                                position: Position {
+                                                                    path: "",
+                                                                    line_number: 1,
+                                                                    column_number: 1,
+                                                                    line: "",
+                                                                },
+                                                            },
+                                                        ),
+                                                        branches: [
+                                                            IfTypeBranch {
+                                                                type_: None(
+                                                                    None {
+                                                                        position: Position {
+                                                                            path: "",
+                                                                            line_number: 1,
+                                                                            column_number: 1,
+                                                                            line: "",
+                                                                        },
+                                                                    },
+                                                                ),
+                                                                expression: Boolean(
+                                                                    Boolean {
+                                                                        value: true,
+                                                                        position: Position {
+                                                                            path: "",
+                                                                            line_number: 1,
+                                                                            column_number: 1,
+                                                                            line: "",
+                                                                        },
+                                                                    },
+                                                                ),
+                                                            },
+                                                        ],
+                                                        else_: None,
+                                                        position: Position {
+                                                            path: "",
+                                                            line_number: 1,
+                                                            column_number: 1,
+                                                            line: "",
+                                                        },
+                                                    },
+                                                ),
+                                            },
+                                        ],
+                                        else_: None,
+                                        position: Position {
+                                            path: "",
+                                            line_number: 1,
+                                            column_number: 1,
+                                            line: "",
+                                        },
+                                    },
+                                ),
+                                position: Position {
+                                    path: "",
+                                    line_number: 1,
+                                    column_number: 1,
+                                    line: "",
+                                },
+                            },
+                        ),
+                        Lambda(
+                            Lambda {
+                                arguments: [
+                                    Argument {
+                                        name: "$x",
+                                        type_: Any(
+                                            Any {
+                                                position: Position {
+                                                    path: "",
+                                                    line_number: 1,
+                                                    column_number: 1,
+                                                    line: "",
+                                                },
+                                            },
+                                        ),
+                                    },
+                                ],
+                                result_type: Number(
+                                    Number {
+                                        position: Position {
+                                            path: "",
+                                            line_number: 1,
+                                            column_number: 1,
+                                            line: "",
+                                        },
+                                    },
+                                ),
+                                body: IfType(
+                                    IfType {
+                                        name: "$x",
+                                        argument: Variable(
+                                            Variable {
+                                                name: "$x",
+                                                position: Position {
+                                                    path: "",
+                                                    line_number: 1,
+                                                    column_number: 1,
+                                                    line: "",
+                                                },
+                                            },
+                                        ),
+                                        branches: [
+                                            IfTypeBranch {
+                                                type_: None(
+                                                    None {
+                                                        position: Position {
+                                                            path: "",
+                                                            line_number: 1,
+                                                            column_number: 1,
+                                                            line: "",
+                                                        },
+                                                    },
+                                                ),
+                                                expression: Number(
+                                                    Number {
+                                                        value: 0.0,
+                                                        position: Position {
+                                                            path: "",
+                                                            line_number: 1,
+                                                            column_number: 1,
+                                                            line: "",
+                                                        },
+                                                    },
+                                                ),
+                                            },
+                                        ],
+                                        else_: None,
+                                        position: Position {
+                                            path: "",
+                                            line_number: 1,
+                                            column_number: 1,
+                                            line: "",
+                                        },
+                                    },
+                                ),
+                                position: Position {
+                                    path: "",
+                                    line_number: 1,
+                                    column_number: 1,
+                                    line: "",
+                                },
+                            },
+                        ),
+                        Lambda(
+                            Lambda {
+                                arguments: [
+                                    Argument {
+                                        name: "$lhs",
+                                        type_: Any(
+                                            Any {
+                                                position: Position {
+                                                    path: "",
+                                                    line_number: 1,
+                                                    column_number: 1,
+                                                    line: "",
+                                                },
+                                            },
+                                        ),
+                                    },
+                                    Argument {
+                                        name: "$rhs",
+                                        type_: Any(
+                                            Any {
+                                                position: Position {
+                                                    path: "",
+                                                    line_number: 1,
+                                                    column_number: 1,
+                                                    line: "",
+                                                },
+                                            },
+                                        ),
+                                    },
+                                ],
+                                result_type: Boolean(
+                                    Boolean {
+                                        position: Position {
+                                            path: "",
+                                            line_number: 1,
+                                            column_number: 1,
+                                            line: "",
+                                        },
+                                    },
+                                ),
+                                body: IfType(
+                                    IfType {
+                                        name: "$lhs",
+                                        argument: Variable(
+                                            Variable {
+                                                name: "$lhs",
+                                                position: Position {
+                                                    path: "",
+                                                    line_number: 1,
+                                                    column_number: 1,
+                                                    line: "",
+                                                },
+                                            },
+                                        ),
+                                        branches: [
+                                            IfTypeBranch {
+                                                type_: None(
+                                                    None {
+                                                        position: Position {
+                                                            path: "",
+                                                            line_number: 1,
+                                                            column_number: 1,
+                                                            line: "",
+                                                        },
+                                                    },
+                                                ),
+                                                expression: IfType(
+                                                    IfType {
+                                                        name: "$rhs",
+                                                        argument: Variable(
+                                                            Variable {
+                                                                name: "$rhs",
+                                                                position: Position {
+                                                                    path: "",
+                                                                    line_number: 1,
+                                                                    column_number: 1,
+                                                                    line: "",
+                                                                },
+                                                            },
+                                                        ),
+                                                        branches: [
+                                                            IfTypeBranch {
+                                                                type_: None(
+                                                                    None {
+                                                                        position: Position {
+                                                                            path: "",
+                                                                            line_number: 1,
+                                                                            column_number: 1,
+                                                                            line: "",
+                                                                        },
+                                                                    },
+                                                                ),
+                                                                expression: Boolean(
+                                                                    Boolean {
+                                                                        value: true,
+                                                                        position: Position {
+                                                                            path: "",
+                                                                            line_number: 1,
+                                                                            column_number: 1,
+                                                                            line: "",
+                                                                        },
+                                                                    },
+                                                                ),
+                                                            },
+                                                        ],
+                                                        else_: None,
+                                                        position: Position {
+                                                            path: "",
+                                                            line_number: 1,
+                                                            column_number: 1,
+                                                            line: "",
+                                                        },
+                                                    },
+                                                ),
+                                            },
+                                        ],
+                                        else_: None,
+                                        position: Position {
+                                            path: "",
+                                            line_number: 1,
+                                            column_number: 1,
+                                            line: "",
+                                        },
+                                    },
+                                ),
+                                position: Position {
+                                    path: "",
+                                    line_number: 1,
+                                    column_number: 1,
+                                    line: "",
+                                },
+                            },
+                        ),
+                        Lambda(
+                            Lambda {
+                                arguments: [
+                                    Argument {
+                                        name: "$x",
+                                        type_: Any(
+                                            Any {
+                                                position: Position {
+                                                    path: "",
+                                                    line_number: 1,
+                                                    column_number: 1,
+                                                    line: "",
+                                                },
+                                            },
+                                        ),
+                                    },
+                                ],
+                                result_type: Number(
+                                    Number {
+                                        position: Position {
+                                            path: "",
+                                            line_number: 1,
+                                            column_number: 1,
+                                            line: "",
+                                        },
+                                    },
+                                ),
+                                body: IfType(
+                                    IfType {
+                                        name: "$x",
+                                        argument: Variable(
+                                            Variable {
+                                                name: "$x",
+                                                position: Position {
+                                                    path: "",
+                                                    line_number: 1,
+                                                    column_number: 1,
+                                                    line: "",
+                                                },
+                                            },
+                                        ),
+                                        branches: [
+                                            IfTypeBranch {
+                                                type_: None(
+                                                    None {
+                                                        position: Position {
+                                                            path: "",
+                                                            line_number: 1,
+                                                            column_number: 1,
+                                                            line: "",
+                                                        },
+                                                    },
+                                                ),
+                                                expression: Number(
+                                                    Number {
+                                                        value: 0.0,
+                                                        position: Position {
+                                                            path: "",
+                                                            line_number: 1,
+                                                            column_number: 1,
+                                                            line: "",
+                                                        },
+                                                    },
+                                                ),
+                                            },
+                                        ],
+                                        else_: None,
+                                        position: Position {
+                                            path: "",
+                                            line_number: 1,
+                                            column_number: 1,
+                                            line: "",
+                                        },
+                                    },
+                                ),
+                                position: Position {
+                                    path: "",
+                                    line_number: 1,
+                                    column_number: 1,
+                                    line: "",
+                                },
+                            },
+                        ),
+                    ],
                     position: Position {
                         path: "",
                         line_number: 1,
@@ -83,163 +649,13 @@ Ok(
                     },
                 },
             ),
-            arguments: [
-                Call(
-                    Call {
-                        function_type: Some(
-                            Function(
-                                Function {
-                                    arguments: [
-                                        Function(
-                                            Function {
-                                                arguments: [
-                                                    Any(
-                                                        Any {
-                                                            position: Position {
-                                                                path: "",
-                                                                line_number: 1,
-                                                                column_number: 1,
-                                                                line: "",
-                                                            },
-                                                        },
-                                                    ),
-                                                    Any(
-                                                        Any {
-                                                            position: Position {
-                                                                path: "",
-                                                                line_number: 1,
-                                                                column_number: 1,
-                                                                line: "",
-                                                            },
-                                                        },
-                                                    ),
-                                                ],
-                                                result: Boolean(
-                                                    Boolean {
-                                                        position: Position {
-                                                            path: "",
-                                                            line_number: 1,
-                                                            column_number: 1,
-                                                            line: "",
-                                                        },
-                                                    },
-                                                ),
-                                                position: Position {
-                                                    path: "",
-                                                    line_number: 1,
-                                                    column_number: 1,
-                                                    line: "",
-                                                },
-                                            },
-                                        ),
-                                        Function(
-                                            Function {
-                                                arguments: [
-                                                    Any(
-                                                        Any {
-                                                            position: Position {
-                                                                path: "",
-                                                                line_number: 1,
-                                                                column_number: 1,
-                                                                line: "",
-                                                            },
-                                                        },
-                                                    ),
-                                                ],
-                                                result: Number(
-                                                    Number {
-                                                        position: Position {
-                                                            path: "",
-                                                            line_number: 1,
-                                                            column_number: 1,
-                                                            line: "",
-                                                        },
-                                                    },
-                                                ),
-                                                position: Position {
-                                                    path: "",
-                                                    line_number: 1,
-                                                    column_number: 1,
-                                                    line: "",
-                                                },
-                                            },
-                                        ),
-                                        Function(
-                                            Function {
-                                                arguments: [
-                                                    Any(
-                                                        Any {
-                                                            position: Position {
-                                                                path: "",
-                                                                line_number: 1,
-                                                                column_number: 1,
-                                                                line: "",
-                                                            },
-                                                        },
-                                                    ),
-                                                    Any(
-                                                        Any {
-                                                            position: Position {
-                                                                path: "",
-                                                                line_number: 1,
-                                                                column_number: 1,
-                                                                line: "",
-                                                            },
-                                                        },
-                                                    ),
-                                                ],
-                                                result: Boolean(
-                                                    Boolean {
-                                                        position: Position {
-                                                            path: "",
-                                                            line_number: 1,
-                                                            column_number: 1,
-                                                            line: "",
-                                                        },
-                                                    },
-                                                ),
-                                                position: Position {
-                                                    path: "",
-                                                    line_number: 1,
-                                                    column_number: 1,
-                                                    line: "",
-                                                },
-                                            },
-                                        ),
-                                        Function(
-                                            Function {
-                                                arguments: [
-                                                    Any(
-                                                        Any {
-                                                            position: Position {
-                                                                path: "",
-                                                                line_number: 1,
-                                                                column_number: 1,
-                                                                line: "",
-                                                            },
-                                                        },
-                                                    ),
-                                                ],
-                                                result: Number(
-                                                    Number {
-                                                        position: Position {
-                                                            path: "",
-                                                            line_number: 1,
-                                                            column_number: 1,
-                                                            line: "",
-                                                        },
-                                                    },
-                                                ),
-                                                position: Position {
-                                                    path: "",
-                                                    line_number: 1,
-                                                    column_number: 1,
-                                                    line: "",
-                                                },
-                                            },
-                                        ),
-                                    ],
-                                    result: Reference(
+            expression: Call(
+                Call {
+                    function_type: Some(
+                        Function(
+                            Function {
+                                arguments: [
+                                    Reference(
                                         Reference {
                                             name: "mapContext",
                                             position: Position {
@@ -250,518 +666,7 @@ Ok(
                                             },
                                         },
                                     ),
-                                    position: Position {
-                                        path: "",
-                                        line_number: 1,
-                                        column_number: 1,
-                                        line: "",
-                                    },
-                                },
-                            ),
-                        ),
-                        function: Variable(
-                            Variable {
-                                name: "newMapContext",
-                                position: Position {
-                                    path: "",
-                                    line_number: 1,
-                                    column_number: 1,
-                                    line: "",
-                                },
-                            },
-                        ),
-                        arguments: [
-                            Lambda(
-                                Lambda {
-                                    arguments: [
-                                        Argument {
-                                            name: "$lhs",
-                                            type_: Any(
-                                                Any {
-                                                    position: Position {
-                                                        path: "",
-                                                        line_number: 1,
-                                                        column_number: 1,
-                                                        line: "",
-                                                    },
-                                                },
-                                            ),
-                                        },
-                                        Argument {
-                                            name: "$rhs",
-                                            type_: Any(
-                                                Any {
-                                                    position: Position {
-                                                        path: "",
-                                                        line_number: 1,
-                                                        column_number: 1,
-                                                        line: "",
-                                                    },
-                                                },
-                                            ),
-                                        },
-                                    ],
-                                    result_type: Boolean(
-                                        Boolean {
-                                            position: Position {
-                                                path: "",
-                                                line_number: 1,
-                                                column_number: 1,
-                                                line: "",
-                                            },
-                                        },
-                                    ),
-                                    body: IfType(
-                                        IfType {
-                                            name: "$lhs",
-                                            argument: Variable(
-                                                Variable {
-                                                    name: "$lhs",
-                                                    position: Position {
-                                                        path: "",
-                                                        line_number: 1,
-                                                        column_number: 1,
-                                                        line: "",
-                                                    },
-                                                },
-                                            ),
-                                            branches: [
-                                                IfTypeBranch {
-                                                    type_: None(
-                                                        None {
-                                                            position: Position {
-                                                                path: "",
-                                                                line_number: 1,
-                                                                column_number: 1,
-                                                                line: "",
-                                                            },
-                                                        },
-                                                    ),
-                                                    expression: IfType(
-                                                        IfType {
-                                                            name: "$rhs",
-                                                            argument: Variable(
-                                                                Variable {
-                                                                    name: "$rhs",
-                                                                    position: Position {
-                                                                        path: "",
-                                                                        line_number: 1,
-                                                                        column_number: 1,
-                                                                        line: "",
-                                                                    },
-                                                                },
-                                                            ),
-                                                            branches: [
-                                                                IfTypeBranch {
-                                                                    type_: None(
-                                                                        None {
-                                                                            position: Position {
-                                                                                path: "",
-                                                                                line_number: 1,
-                                                                                column_number: 1,
-                                                                                line: "",
-                                                                            },
-                                                                        },
-                                                                    ),
-                                                                    expression: Boolean(
-                                                                        Boolean {
-                                                                            value: true,
-                                                                            position: Position {
-                                                                                path: "",
-                                                                                line_number: 1,
-                                                                                column_number: 1,
-                                                                                line: "",
-                                                                            },
-                                                                        },
-                                                                    ),
-                                                                },
-                                                            ],
-                                                            else_: None,
-                                                            position: Position {
-                                                                path: "",
-                                                                line_number: 1,
-                                                                column_number: 1,
-                                                                line: "",
-                                                            },
-                                                        },
-                                                    ),
-                                                },
-                                            ],
-                                            else_: None,
-                                            position: Position {
-                                                path: "",
-                                                line_number: 1,
-                                                column_number: 1,
-                                                line: "",
-                                            },
-                                        },
-                                    ),
-                                    position: Position {
-                                        path: "",
-                                        line_number: 1,
-                                        column_number: 1,
-                                        line: "",
-                                    },
-                                },
-                            ),
-                            Lambda(
-                                Lambda {
-                                    arguments: [
-                                        Argument {
-                                            name: "$x",
-                                            type_: Any(
-                                                Any {
-                                                    position: Position {
-                                                        path: "",
-                                                        line_number: 1,
-                                                        column_number: 1,
-                                                        line: "",
-                                                    },
-                                                },
-                                            ),
-                                        },
-                                    ],
-                                    result_type: Number(
-                                        Number {
-                                            position: Position {
-                                                path: "",
-                                                line_number: 1,
-                                                column_number: 1,
-                                                line: "",
-                                            },
-                                        },
-                                    ),
-                                    body: IfType(
-                                        IfType {
-                                            name: "$x",
-                                            argument: Variable(
-                                                Variable {
-                                                    name: "$x",
-                                                    position: Position {
-                                                        path: "",
-                                                        line_number: 1,
-                                                        column_number: 1,
-                                                        line: "",
-                                                    },
-                                                },
-                                            ),
-                                            branches: [
-                                                IfTypeBranch {
-                                                    type_: None(
-                                                        None {
-                                                            position: Position {
-                                                                path: "",
-                                                                line_number: 1,
-                                                                column_number: 1,
-                                                                line: "",
-                                                            },
-                                                        },
-                                                    ),
-                                                    expression: Number(
-                                                        Number {
-                                                            value: 0.0,
-                                                            position: Position {
-                                                                path: "",
-                                                                line_number: 1,
-                                                                column_number: 1,
-                                                                line: "",
-                                                            },
-                                                        },
-                                                    ),
-                                                },
-                                            ],
-                                            else_: None,
-                                            position: Position {
-                                                path: "",
-                                                line_number: 1,
-                                                column_number: 1,
-                                                line: "",
-                                            },
-                                        },
-                                    ),
-                                    position: Position {
-                                        path: "",
-                                        line_number: 1,
-                                        column_number: 1,
-                                        line: "",
-                                    },
-                                },
-                            ),
-                            Lambda(
-                                Lambda {
-                                    arguments: [
-                                        Argument {
-                                            name: "$lhs",
-                                            type_: Any(
-                                                Any {
-                                                    position: Position {
-                                                        path: "",
-                                                        line_number: 1,
-                                                        column_number: 1,
-                                                        line: "",
-                                                    },
-                                                },
-                                            ),
-                                        },
-                                        Argument {
-                                            name: "$rhs",
-                                            type_: Any(
-                                                Any {
-                                                    position: Position {
-                                                        path: "",
-                                                        line_number: 1,
-                                                        column_number: 1,
-                                                        line: "",
-                                                    },
-                                                },
-                                            ),
-                                        },
-                                    ],
-                                    result_type: Boolean(
-                                        Boolean {
-                                            position: Position {
-                                                path: "",
-                                                line_number: 1,
-                                                column_number: 1,
-                                                line: "",
-                                            },
-                                        },
-                                    ),
-                                    body: IfType(
-                                        IfType {
-                                            name: "$lhs",
-                                            argument: Variable(
-                                                Variable {
-                                                    name: "$lhs",
-                                                    position: Position {
-                                                        path: "",
-                                                        line_number: 1,
-                                                        column_number: 1,
-                                                        line: "",
-                                                    },
-                                                },
-                                            ),
-                                            branches: [
-                                                IfTypeBranch {
-                                                    type_: None(
-                                                        None {
-                                                            position: Position {
-                                                                path: "",
-                                                                line_number: 1,
-                                                                column_number: 1,
-                                                                line: "",
-                                                            },
-                                                        },
-                                                    ),
-                                                    expression: IfType(
-                                                        IfType {
-                                                            name: "$rhs",
-                                                            argument: Variable(
-                                                                Variable {
-                                                                    name: "$rhs",
-                                                                    position: Position {
-                                                                        path: "",
-                                                                        line_number: 1,
-                                                                        column_number: 1,
-                                                                        line: "",
-                                                                    },
-                                                                },
-                                                            ),
-                                                            branches: [
-                                                                IfTypeBranch {
-                                                                    type_: None(
-                                                                        None {
-                                                                            position: Position {
-                                                                                path: "",
-                                                                                line_number: 1,
-                                                                                column_number: 1,
-                                                                                line: "",
-                                                                            },
-                                                                        },
-                                                                    ),
-                                                                    expression: Boolean(
-                                                                        Boolean {
-                                                                            value: true,
-                                                                            position: Position {
-                                                                                path: "",
-                                                                                line_number: 1,
-                                                                                column_number: 1,
-                                                                                line: "",
-                                                                            },
-                                                                        },
-                                                                    ),
-                                                                },
-                                                            ],
-                                                            else_: None,
-                                                            position: Position {
-                                                                path: "",
-                                                                line_number: 1,
-                                                                column_number: 1,
-                                                                line: "",
-                                                            },
-                                                        },
-                                                    ),
-                                                },
-                                            ],
-                                            else_: None,
-                                            position: Position {
-                                                path: "",
-                                                line_number: 1,
-                                                column_number: 1,
-                                                line: "",
-                                            },
-                                        },
-                                    ),
-                                    position: Position {
-                                        path: "",
-                                        line_number: 1,
-                                        column_number: 1,
-                                        line: "",
-                                    },
-                                },
-                            ),
-                            Lambda(
-                                Lambda {
-                                    arguments: [
-                                        Argument {
-                                            name: "$x",
-                                            type_: Any(
-                                                Any {
-                                                    position: Position {
-                                                        path: "",
-                                                        line_number: 1,
-                                                        column_number: 1,
-                                                        line: "",
-                                                    },
-                                                },
-                                            ),
-                                        },
-                                    ],
-                                    result_type: Number(
-                                        Number {
-                                            position: Position {
-                                                path: "",
-                                                line_number: 1,
-                                                column_number: 1,
-                                                line: "",
-                                            },
-                                        },
-                                    ),
-                                    body: IfType(
-                                        IfType {
-                                            name: "$x",
-                                            argument: Variable(
-                                                Variable {
-                                                    name: "$x",
-                                                    position: Position {
-                                                        path: "",
-                                                        line_number: 1,
-                                                        column_number: 1,
-                                                        line: "",
-                                                    },
-                                                },
-                                            ),
-                                            branches: [
-                                                IfTypeBranch {
-                                                    type_: None(
-                                                        None {
-                                                            position: Position {
-                                                                path: "",
-                                                                line_number: 1,
-                                                                column_number: 1,
-                                                                line: "",
-                                                            },
-                                                        },
-                                                    ),
-                                                    expression: Number(
-                                                        Number {
-                                                            value: 0.0,
-                                                            position: Position {
-                                                                path: "",
-                                                                line_number: 1,
-                                                                column_number: 1,
-                                                                line: "",
-                                                            },
-                                                        },
-                                                    ),
-                                                },
-                                            ],
-                                            else_: None,
-                                            position: Position {
-                                                path: "",
-                                                line_number: 1,
-                                                column_number: 1,
-                                                line: "",
-                                            },
-                                        },
-                                    ),
-                                    position: Position {
-                                        path: "",
-                                        line_number: 1,
-                                        column_number: 1,
-                                        line: "",
-                                    },
-                                },
-                            ),
-                        ],
-                        position: Position {
-                            path: "",
-                            line_number: 1,
-                            column_number: 1,
-                            line: "",
-                        },
-                    },
-                ),
-                Call(
-                    Call {
-                        function_type: Some(
-                            Function(
-                                Function {
-                                    arguments: [
-                                        Reference(
-                                            Reference {
-                                                name: "mapContext",
-                                                position: Position {
-                                                    path: "",
-                                                    line_number: 1,
-                                                    column_number: 1,
-                                                    line: "",
-                                                },
-                                            },
-                                        ),
-                                        Reference(
-                                            Reference {
-                                                name: "GenericMap",
-                                                position: Position {
-                                                    path: "",
-                                                    line_number: 1,
-                                                    column_number: 1,
-                                                    line: "",
-                                                },
-                                            },
-                                        ),
-                                        Any(
-                                            Any {
-                                                position: Position {
-                                                    path: "",
-                                                    line_number: 1,
-                                                    column_number: 1,
-                                                    line: "",
-                                                },
-                                            },
-                                        ),
-                                        Any(
-                                            Any {
-                                                position: Position {
-                                                    path: "",
-                                                    line_number: 1,
-                                                    column_number: 1,
-                                                    line: "",
-                                                },
-                                            },
-                                        ),
-                                    ],
-                                    result: Reference(
+                                    Reference(
                                         Reference {
                                             name: "GenericMap",
                                             position: Position {
@@ -772,18 +677,38 @@ Ok(
                                             },
                                         },
                                     ),
-                                    position: Position {
-                                        path: "",
-                                        line_number: 1,
-                                        column_number: 1,
-                                        line: "",
+                                    Any(
+                                        Any {
+                                            position: Position {
+                                                path: "",
+                                                line_number: 1,
+                                                column_number: 1,
+                                                line: "",
+                                            },
+                                        },
+                                    ),
+                                    Any(
+                                        Any {
+                                            position: Position {
+                                                path: "",
+                                                line_number: 1,
+                                                column_number: 1,
+                                                line: "",
+                                            },
+                                        },
+                                    ),
+                                ],
+                                result: Reference(
+                                    Reference {
+                                        name: "GenericMap",
+                                        position: Position {
+                                            path: "",
+                                            line_number: 1,
+                                            column_number: 1,
+                                            line: "",
+                                        },
                                     },
-                                },
-                            ),
-                        ),
-                        function: Variable(
-                            Variable {
-                                name: "setMap",
+                                ),
                                 position: Position {
                                     path: "",
                                     line_number: 1,
@@ -792,163 +717,37 @@ Ok(
                                 },
                             },
                         ),
-                        arguments: [
-                            Call(
-                                Call {
-                                    function_type: Some(
-                                        Function(
-                                            Function {
-                                                arguments: [
-                                                    Function(
-                                                        Function {
-                                                            arguments: [
-                                                                Any(
-                                                                    Any {
-                                                                        position: Position {
-                                                                            path: "",
-                                                                            line_number: 1,
-                                                                            column_number: 1,
-                                                                            line: "",
-                                                                        },
-                                                                    },
-                                                                ),
-                                                                Any(
-                                                                    Any {
-                                                                        position: Position {
-                                                                            path: "",
-                                                                            line_number: 1,
-                                                                            column_number: 1,
-                                                                            line: "",
-                                                                        },
-                                                                    },
-                                                                ),
-                                                            ],
-                                                            result: Boolean(
-                                                                Boolean {
-                                                                    position: Position {
-                                                                        path: "",
-                                                                        line_number: 1,
-                                                                        column_number: 1,
-                                                                        line: "",
-                                                                    },
-                                                                },
-                                                            ),
-                                                            position: Position {
-                                                                path: "",
-                                                                line_number: 1,
-                                                                column_number: 1,
-                                                                line: "",
-                                                            },
-                                                        },
-                                                    ),
-                                                    Function(
-                                                        Function {
-                                                            arguments: [
-                                                                Any(
-                                                                    Any {
-                                                                        position: Position {
-                                                                            path: "",
-                                                                            line_number: 1,
-                                                                            column_number: 1,
-                                                                            line: "",
-                                                                        },
-                                                                    },
-                                                                ),
-                                                            ],
-                                                            result: Number(
-                                                                Number {
-                                                                    position: Position {
-                                                                        path: "",
-                                                                        line_number: 1,
-                                                                        column_number: 1,
-                                                                        line: "",
-                                                                    },
-                                                                },
-                                                            ),
-                                                            position: Position {
-                                                                path: "",
-                                                                line_number: 1,
-                                                                column_number: 1,
-                                                                line: "",
-                                                            },
-                                                        },
-                                                    ),
-                                                    Function(
-                                                        Function {
-                                                            arguments: [
-                                                                Any(
-                                                                    Any {
-                                                                        position: Position {
-                                                                            path: "",
-                                                                            line_number: 1,
-                                                                            column_number: 1,
-                                                                            line: "",
-                                                                        },
-                                                                    },
-                                                                ),
-                                                                Any(
-                                                                    Any {
-                                                                        position: Position {
-                                                                            path: "",
-                                                                            line_number: 1,
-                                                                            column_number: 1,
-                                                                            line: "",
-                                                                        },
-                                                                    },
-                                                                ),
-                                                            ],
-                                                            result: Boolean(
-                                                                Boolean {
-                                                                    position: Position {
-                                                                        path: "",
-                                                                        line_number: 1,
-                                                                        column_number: 1,
-                                                                        line: "",
-                                                                    },
-                                                                },
-                                                            ),
-                                                            position: Position {
-                                                                path: "",
-                                                                line_number: 1,
-                                                                column_number: 1,
-                                                                line: "",
-                                                            },
-                                                        },
-                                                    ),
-                                                    Function(
-                                                        Function {
-                                                            arguments: [
-                                                                Any(
-                                                                    Any {
-                                                                        position: Position {
-                                                                            path: "",
-                                                                            line_number: 1,
-                                                                            column_number: 1,
-                                                                            line: "",
-                                                                        },
-                                                                    },
-                                                                ),
-                                                            ],
-                                                            result: Number(
-                                                                Number {
-                                                                    position: Position {
-                                                                        path: "",
-                                                                        line_number: 1,
-                                                                        column_number: 1,
-                                                                        line: "",
-                                                                    },
-                                                                },
-                                                            ),
-                                                            position: Position {
-                                                                path: "",
-                                                                line_number: 1,
-                                                                column_number: 1,
-                                                                line: "",
-                                                            },
-                                                        },
-                                                    ),
-                                                ],
-                                                result: Reference(
+                    ),
+                    function: Variable(
+                        Variable {
+                            name: "setMap",
+                            position: Position {
+                                path: "",
+                                line_number: 1,
+                                column_number: 1,
+                                line: "",
+                            },
+                        },
+                    ),
+                    arguments: [
+                        Variable(
+                            Variable {
+                                name: "$ctx",
+                                position: Position {
+                                    path: "",
+                                    line_number: 1,
+                                    column_number: 1,
+                                    line: "",
+                                },
+                            },
+                        ),
+                        Call(
+                            Call {
+                                function_type: Some(
+                                    Function(
+                                        Function {
+                                            arguments: [
+                                                Reference(
                                                     Reference {
                                                         name: "mapContext",
                                                         position: Position {
@@ -959,475 +758,7 @@ Ok(
                                                         },
                                                     },
                                                 ),
-                                                position: Position {
-                                                    path: "",
-                                                    line_number: 1,
-                                                    column_number: 1,
-                                                    line: "",
-                                                },
-                                            },
-                                        ),
-                                    ),
-                                    function: Variable(
-                                        Variable {
-                                            name: "newMapContext",
-                                            position: Position {
-                                                path: "",
-                                                line_number: 1,
-                                                column_number: 1,
-                                                line: "",
-                                            },
-                                        },
-                                    ),
-                                    arguments: [
-                                        Lambda(
-                                            Lambda {
-                                                arguments: [
-                                                    Argument {
-                                                        name: "$lhs",
-                                                        type_: Any(
-                                                            Any {
-                                                                position: Position {
-                                                                    path: "",
-                                                                    line_number: 1,
-                                                                    column_number: 1,
-                                                                    line: "",
-                                                                },
-                                                            },
-                                                        ),
-                                                    },
-                                                    Argument {
-                                                        name: "$rhs",
-                                                        type_: Any(
-                                                            Any {
-                                                                position: Position {
-                                                                    path: "",
-                                                                    line_number: 1,
-                                                                    column_number: 1,
-                                                                    line: "",
-                                                                },
-                                                            },
-                                                        ),
-                                                    },
-                                                ],
-                                                result_type: Boolean(
-                                                    Boolean {
-                                                        position: Position {
-                                                            path: "",
-                                                            line_number: 1,
-                                                            column_number: 1,
-                                                            line: "",
-                                                        },
-                                                    },
-                                                ),
-                                                body: IfType(
-                                                    IfType {
-                                                        name: "$lhs",
-                                                        argument: Variable(
-                                                            Variable {
-                                                                name: "$lhs",
-                                                                position: Position {
-                                                                    path: "",
-                                                                    line_number: 1,
-                                                                    column_number: 1,
-                                                                    line: "",
-                                                                },
-                                                            },
-                                                        ),
-                                                        branches: [
-                                                            IfTypeBranch {
-                                                                type_: None(
-                                                                    None {
-                                                                        position: Position {
-                                                                            path: "",
-                                                                            line_number: 1,
-                                                                            column_number: 1,
-                                                                            line: "",
-                                                                        },
-                                                                    },
-                                                                ),
-                                                                expression: IfType(
-                                                                    IfType {
-                                                                        name: "$rhs",
-                                                                        argument: Variable(
-                                                                            Variable {
-                                                                                name: "$rhs",
-                                                                                position: Position {
-                                                                                    path: "",
-                                                                                    line_number: 1,
-                                                                                    column_number: 1,
-                                                                                    line: "",
-                                                                                },
-                                                                            },
-                                                                        ),
-                                                                        branches: [
-                                                                            IfTypeBranch {
-                                                                                type_: None(
-                                                                                    None {
-                                                                                        position: Position {
-                                                                                            path: "",
-                                                                                            line_number: 1,
-                                                                                            column_number: 1,
-                                                                                            line: "",
-                                                                                        },
-                                                                                    },
-                                                                                ),
-                                                                                expression: Boolean(
-                                                                                    Boolean {
-                                                                                        value: true,
-                                                                                        position: Position {
-                                                                                            path: "",
-                                                                                            line_number: 1,
-                                                                                            column_number: 1,
-                                                                                            line: "",
-                                                                                        },
-                                                                                    },
-                                                                                ),
-                                                                            },
-                                                                        ],
-                                                                        else_: None,
-                                                                        position: Position {
-                                                                            path: "",
-                                                                            line_number: 1,
-                                                                            column_number: 1,
-                                                                            line: "",
-                                                                        },
-                                                                    },
-                                                                ),
-                                                            },
-                                                        ],
-                                                        else_: None,
-                                                        position: Position {
-                                                            path: "",
-                                                            line_number: 1,
-                                                            column_number: 1,
-                                                            line: "",
-                                                        },
-                                                    },
-                                                ),
-                                                position: Position {
-                                                    path: "",
-                                                    line_number: 1,
-                                                    column_number: 1,
-                                                    line: "",
-                                                },
-                                            },
-                                        ),
-                                        Lambda(
-                                            Lambda {
-                                                arguments: [
-                                                    Argument {
-                                                        name: "$x",
-                                                        type_: Any(
-                                                            Any {
-                                                                position: Position {
-                                                                    path: "",
-                                                                    line_number: 1,
-                                                                    column_number: 1,
-                                                                    line: "",
-                                                                },
-                                                            },
-                                                        ),
-                                                    },
-                                                ],
-                                                result_type: Number(
-                                                    Number {
-                                                        position: Position {
-                                                            path: "",
-                                                            line_number: 1,
-                                                            column_number: 1,
-                                                            line: "",
-                                                        },
-                                                    },
-                                                ),
-                                                body: IfType(
-                                                    IfType {
-                                                        name: "$x",
-                                                        argument: Variable(
-                                                            Variable {
-                                                                name: "$x",
-                                                                position: Position {
-                                                                    path: "",
-                                                                    line_number: 1,
-                                                                    column_number: 1,
-                                                                    line: "",
-                                                                },
-                                                            },
-                                                        ),
-                                                        branches: [
-                                                            IfTypeBranch {
-                                                                type_: None(
-                                                                    None {
-                                                                        position: Position {
-                                                                            path: "",
-                                                                            line_number: 1,
-                                                                            column_number: 1,
-                                                                            line: "",
-                                                                        },
-                                                                    },
-                                                                ),
-                                                                expression: Number(
-                                                                    Number {
-                                                                        value: 0.0,
-                                                                        position: Position {
-                                                                            path: "",
-                                                                            line_number: 1,
-                                                                            column_number: 1,
-                                                                            line: "",
-                                                                        },
-                                                                    },
-                                                                ),
-                                                            },
-                                                        ],
-                                                        else_: None,
-                                                        position: Position {
-                                                            path: "",
-                                                            line_number: 1,
-                                                            column_number: 1,
-                                                            line: "",
-                                                        },
-                                                    },
-                                                ),
-                                                position: Position {
-                                                    path: "",
-                                                    line_number: 1,
-                                                    column_number: 1,
-                                                    line: "",
-                                                },
-                                            },
-                                        ),
-                                        Lambda(
-                                            Lambda {
-                                                arguments: [
-                                                    Argument {
-                                                        name: "$lhs",
-                                                        type_: Any(
-                                                            Any {
-                                                                position: Position {
-                                                                    path: "",
-                                                                    line_number: 1,
-                                                                    column_number: 1,
-                                                                    line: "",
-                                                                },
-                                                            },
-                                                        ),
-                                                    },
-                                                    Argument {
-                                                        name: "$rhs",
-                                                        type_: Any(
-                                                            Any {
-                                                                position: Position {
-                                                                    path: "",
-                                                                    line_number: 1,
-                                                                    column_number: 1,
-                                                                    line: "",
-                                                                },
-                                                            },
-                                                        ),
-                                                    },
-                                                ],
-                                                result_type: Boolean(
-                                                    Boolean {
-                                                        position: Position {
-                                                            path: "",
-                                                            line_number: 1,
-                                                            column_number: 1,
-                                                            line: "",
-                                                        },
-                                                    },
-                                                ),
-                                                body: IfType(
-                                                    IfType {
-                                                        name: "$lhs",
-                                                        argument: Variable(
-                                                            Variable {
-                                                                name: "$lhs",
-                                                                position: Position {
-                                                                    path: "",
-                                                                    line_number: 1,
-                                                                    column_number: 1,
-                                                                    line: "",
-                                                                },
-                                                            },
-                                                        ),
-                                                        branches: [
-                                                            IfTypeBranch {
-                                                                type_: None(
-                                                                    None {
-                                                                        position: Position {
-                                                                            path: "",
-                                                                            line_number: 1,
-                                                                            column_number: 1,
-                                                                            line: "",
-                                                                        },
-                                                                    },
-                                                                ),
-                                                                expression: IfType(
-                                                                    IfType {
-                                                                        name: "$rhs",
-                                                                        argument: Variable(
-                                                                            Variable {
-                                                                                name: "$rhs",
-                                                                                position: Position {
-                                                                                    path: "",
-                                                                                    line_number: 1,
-                                                                                    column_number: 1,
-                                                                                    line: "",
-                                                                                },
-                                                                            },
-                                                                        ),
-                                                                        branches: [
-                                                                            IfTypeBranch {
-                                                                                type_: None(
-                                                                                    None {
-                                                                                        position: Position {
-                                                                                            path: "",
-                                                                                            line_number: 1,
-                                                                                            column_number: 1,
-                                                                                            line: "",
-                                                                                        },
-                                                                                    },
-                                                                                ),
-                                                                                expression: Boolean(
-                                                                                    Boolean {
-                                                                                        value: true,
-                                                                                        position: Position {
-                                                                                            path: "",
-                                                                                            line_number: 1,
-                                                                                            column_number: 1,
-                                                                                            line: "",
-                                                                                        },
-                                                                                    },
-                                                                                ),
-                                                                            },
-                                                                        ],
-                                                                        else_: None,
-                                                                        position: Position {
-                                                                            path: "",
-                                                                            line_number: 1,
-                                                                            column_number: 1,
-                                                                            line: "",
-                                                                        },
-                                                                    },
-                                                                ),
-                                                            },
-                                                        ],
-                                                        else_: None,
-                                                        position: Position {
-                                                            path: "",
-                                                            line_number: 1,
-                                                            column_number: 1,
-                                                            line: "",
-                                                        },
-                                                    },
-                                                ),
-                                                position: Position {
-                                                    path: "",
-                                                    line_number: 1,
-                                                    column_number: 1,
-                                                    line: "",
-                                                },
-                                            },
-                                        ),
-                                        Lambda(
-                                            Lambda {
-                                                arguments: [
-                                                    Argument {
-                                                        name: "$x",
-                                                        type_: Any(
-                                                            Any {
-                                                                position: Position {
-                                                                    path: "",
-                                                                    line_number: 1,
-                                                                    column_number: 1,
-                                                                    line: "",
-                                                                },
-                                                            },
-                                                        ),
-                                                    },
-                                                ],
-                                                result_type: Number(
-                                                    Number {
-                                                        position: Position {
-                                                            path: "",
-                                                            line_number: 1,
-                                                            column_number: 1,
-                                                            line: "",
-                                                        },
-                                                    },
-                                                ),
-                                                body: IfType(
-                                                    IfType {
-                                                        name: "$x",
-                                                        argument: Variable(
-                                                            Variable {
-                                                                name: "$x",
-                                                                position: Position {
-                                                                    path: "",
-                                                                    line_number: 1,
-                                                                    column_number: 1,
-                                                                    line: "",
-                                                                },
-                                                            },
-                                                        ),
-                                                        branches: [
-                                                            IfTypeBranch {
-                                                                type_: None(
-                                                                    None {
-                                                                        position: Position {
-                                                                            path: "",
-                                                                            line_number: 1,
-                                                                            column_number: 1,
-                                                                            line: "",
-                                                                        },
-                                                                    },
-                                                                ),
-                                                                expression: Number(
-                                                                    Number {
-                                                                        value: 0.0,
-                                                                        position: Position {
-                                                                            path: "",
-                                                                            line_number: 1,
-                                                                            column_number: 1,
-                                                                            line: "",
-                                                                        },
-                                                                    },
-                                                                ),
-                                                            },
-                                                        ],
-                                                        else_: None,
-                                                        position: Position {
-                                                            path: "",
-                                                            line_number: 1,
-                                                            column_number: 1,
-                                                            line: "",
-                                                        },
-                                                    },
-                                                ),
-                                                position: Position {
-                                                    path: "",
-                                                    line_number: 1,
-                                                    column_number: 1,
-                                                    line: "",
-                                                },
-                                            },
-                                        ),
-                                    ],
-                                    position: Position {
-                                        path: "",
-                                        line_number: 1,
-                                        column_number: 1,
-                                        line: "",
-                                    },
-                                },
-                            ),
-                            Call(
-                                Call {
-                                    function_type: Some(
-                                        Function(
-                                            Function {
-                                                arguments: [],
-                                                result: Reference(
+                                                Reference(
                                                     Reference {
                                                         name: "GenericMap",
                                                         position: Position {
@@ -1438,18 +769,62 @@ Ok(
                                                         },
                                                     },
                                                 ),
-                                                position: Position {
-                                                    path: "",
-                                                    line_number: 1,
-                                                    column_number: 1,
-                                                    line: "",
+                                                Any(
+                                                    Any {
+                                                        position: Position {
+                                                            path: "",
+                                                            line_number: 1,
+                                                            column_number: 1,
+                                                            line: "",
+                                                        },
+                                                    },
+                                                ),
+                                                Any(
+                                                    Any {
+                                                        position: Position {
+                                                            path: "",
+                                                            line_number: 1,
+                                                            column_number: 1,
+                                                            line: "",
+                                                        },
+                                                    },
+                                                ),
+                                            ],
+                                            result: Reference(
+                                                Reference {
+                                                    name: "GenericMap",
+                                                    position: Position {
+                                                        path: "",
+                                                        line_number: 1,
+                                                        column_number: 1,
+                                                        line: "",
+                                                    },
                                                 },
+                                            ),
+                                            position: Position {
+                                                path: "",
+                                                line_number: 1,
+                                                column_number: 1,
+                                                line: "",
                                             },
-                                        ),
+                                        },
                                     ),
-                                    function: Variable(
+                                ),
+                                function: Variable(
+                                    Variable {
+                                        name: "setMap",
+                                        position: Position {
+                                            path: "",
+                                            line_number: 1,
+                                            column_number: 1,
+                                            line: "",
+                                        },
+                                    },
+                                ),
+                                arguments: [
+                                    Variable(
                                         Variable {
-                                            name: "emptyMap",
+                                            name: "$ctx",
                                             position: Position {
                                                 path: "",
                                                 line_number: 1,
@@ -1458,187 +833,232 @@ Ok(
                                             },
                                         },
                                     ),
-                                    arguments: [],
-                                    position: Position {
-                                        path: "",
-                                        line_number: 1,
-                                        column_number: 1,
-                                        line: "",
+                                    Call(
+                                        Call {
+                                            function_type: Some(
+                                                Function(
+                                                    Function {
+                                                        arguments: [],
+                                                        result: Reference(
+                                                            Reference {
+                                                                name: "GenericMap",
+                                                                position: Position {
+                                                                    path: "",
+                                                                    line_number: 1,
+                                                                    column_number: 1,
+                                                                    line: "",
+                                                                },
+                                                            },
+                                                        ),
+                                                        position: Position {
+                                                            path: "",
+                                                            line_number: 1,
+                                                            column_number: 1,
+                                                            line: "",
+                                                        },
+                                                    },
+                                                ),
+                                            ),
+                                            function: Variable(
+                                                Variable {
+                                                    name: "emptyMap",
+                                                    position: Position {
+                                                        path: "",
+                                                        line_number: 1,
+                                                        column_number: 1,
+                                                        line: "",
+                                                    },
+                                                },
+                                            ),
+                                            arguments: [],
+                                            position: Position {
+                                                path: "",
+                                                line_number: 1,
+                                                column_number: 1,
+                                                line: "",
+                                            },
+                                        },
+                                    ),
+                                    TypeCoercion(
+                                        TypeCoercion {
+                                            from: None(
+                                                None {
+                                                    position: Position {
+                                                        path: "",
+                                                        line_number: 1,
+                                                        column_number: 1,
+                                                        line: "",
+                                                    },
+                                                },
+                                            ),
+                                            to: Any(
+                                                Any {
+                                                    position: Position {
+                                                        path: "",
+                                                        line_number: 1,
+                                                        column_number: 1,
+                                                        line: "",
+                                                    },
+                                                },
+                                            ),
+                                            argument: Number(
+                                                Number {
+                                                    value: 1.0,
+                                                    position: Position {
+                                                        path: "",
+                                                        line_number: 1,
+                                                        column_number: 1,
+                                                        line: "",
+                                                    },
+                                                },
+                                            ),
+                                            position: Position {
+                                                path: "",
+                                                line_number: 1,
+                                                column_number: 1,
+                                                line: "",
+                                            },
+                                        },
+                                    ),
+                                    TypeCoercion(
+                                        TypeCoercion {
+                                            from: None(
+                                                None {
+                                                    position: Position {
+                                                        path: "",
+                                                        line_number: 1,
+                                                        column_number: 1,
+                                                        line: "",
+                                                    },
+                                                },
+                                            ),
+                                            to: Any(
+                                                Any {
+                                                    position: Position {
+                                                        path: "",
+                                                        line_number: 1,
+                                                        column_number: 1,
+                                                        line: "",
+                                                    },
+                                                },
+                                            ),
+                                            argument: None(
+                                                None {
+                                                    position: Position {
+                                                        path: "",
+                                                        line_number: 1,
+                                                        column_number: 1,
+                                                        line: "",
+                                                    },
+                                                },
+                                            ),
+                                            position: Position {
+                                                path: "",
+                                                line_number: 1,
+                                                column_number: 1,
+                                                line: "",
+                                            },
+                                        },
+                                    ),
+                                ],
+                                position: Position {
+                                    path: "",
+                                    line_number: 1,
+                                    column_number: 1,
+                                    line: "",
+                                },
+                            },
+                        ),
+                        TypeCoercion(
+                            TypeCoercion {
+                                from: None(
+                                    None {
+                                        position: Position {
+                                            path: "",
+                                            line_number: 1,
+                                            column_number: 1,
+                                            line: "",
+                                        },
                                     },
-                                },
-                            ),
-                            TypeCoercion(
-                                TypeCoercion {
-                                    from: None(
-                                        None {
-                                            position: Position {
-                                                path: "",
-                                                line_number: 1,
-                                                column_number: 1,
-                                                line: "",
-                                            },
+                                ),
+                                to: Any(
+                                    Any {
+                                        position: Position {
+                                            path: "",
+                                            line_number: 1,
+                                            column_number: 1,
+                                            line: "",
                                         },
-                                    ),
-                                    to: Any(
-                                        Any {
-                                            position: Position {
-                                                path: "",
-                                                line_number: 1,
-                                                column_number: 1,
-                                                line: "",
-                                            },
-                                        },
-                                    ),
-                                    argument: Number(
-                                        Number {
-                                            value: 1.0,
-                                            position: Position {
-                                                path: "",
-                                                line_number: 1,
-                                                column_number: 1,
-                                                line: "",
-                                            },
-                                        },
-                                    ),
-                                    position: Position {
-                                        path: "",
-                                        line_number: 1,
-                                        column_number: 1,
-                                        line: "",
                                     },
-                                },
-                            ),
-                            TypeCoercion(
-                                TypeCoercion {
-                                    from: None(
-                                        None {
-                                            position: Position {
-                                                path: "",
-                                                line_number: 1,
-                                                column_number: 1,
-                                                line: "",
-                                            },
+                                ),
+                                argument: Number(
+                                    Number {
+                                        value: 2.0,
+                                        position: Position {
+                                            path: "",
+                                            line_number: 1,
+                                            column_number: 1,
+                                            line: "",
                                         },
-                                    ),
-                                    to: Any(
-                                        Any {
-                                            position: Position {
-                                                path: "",
-                                                line_number: 1,
-                                                column_number: 1,
-                                                line: "",
-                                            },
-                                        },
-                                    ),
-                                    argument: None(
-                                        None {
-                                            position: Position {
-                                                path: "",
-                                                line_number: 1,
-                                                column_number: 1,
-                                                line: "",
-                                            },
-                                        },
-                                    ),
-                                    position: Position {
-                                        path: "",
-                                        line_number: 1,
-                                        column_number: 1,
-                                        line: "",
                                     },
+                                ),
+                                position: Position {
+                                    path: "",
+                                    line_number: 1,
+                                    column_number: 1,
+                                    line: "",
                                 },
-                            ),
-                        ],
-                        position: Position {
-                            path: "",
-                            line_number: 1,
-                            column_number: 1,
-                            line: "",
-                        },
+                            },
+                        ),
+                        TypeCoercion(
+                            TypeCoercion {
+                                from: None(
+                                    None {
+                                        position: Position {
+                                            path: "",
+                                            line_number: 1,
+                                            column_number: 1,
+                                            line: "",
+                                        },
+                                    },
+                                ),
+                                to: Any(
+                                    Any {
+                                        position: Position {
+                                            path: "",
+                                            line_number: 1,
+                                            column_number: 1,
+                                            line: "",
+                                        },
+                                    },
+                                ),
+                                argument: None(
+                                    None {
+                                        position: Position {
+                                            path: "",
+                                            line_number: 1,
+                                            column_number: 1,
+                                            line: "",
+                                        },
+                                    },
+                                ),
+                                position: Position {
+                                    path: "",
+                                    line_number: 1,
+                                    column_number: 1,
+                                    line: "",
+                                },
+                            },
+                        ),
+                    ],
+                    position: Position {
+                        path: "",
+                        line_number: 1,
+                        column_number: 1,
+                        line: "",
                     },
-                ),
-                TypeCoercion(
-                    TypeCoercion {
-                        from: None(
-                            None {
-                                position: Position {
-                                    path: "",
-                                    line_number: 1,
-                                    column_number: 1,
-                                    line: "",
-                                },
-                            },
-                        ),
-                        to: Any(
-                            Any {
-                                position: Position {
-                                    path: "",
-                                    line_number: 1,
-                                    column_number: 1,
-                                    line: "",
-                                },
-                            },
-                        ),
-                        argument: Number(
-                            Number {
-                                value: 2.0,
-                                position: Position {
-                                    path: "",
-                                    line_number: 1,
-                                    column_number: 1,
-                                    line: "",
-                                },
-                            },
-                        ),
-                        position: Position {
-                            path: "",
-                            line_number: 1,
-                            column_number: 1,
-                            line: "",
-                        },
-                    },
-                ),
-                TypeCoercion(
-                    TypeCoercion {
-                        from: None(
-                            None {
-                                position: Position {
-                                    path: "",
-                                    line_number: 1,
-                                    column_number: 1,
-                                    line: "",
-                                },
-                            },
-                        ),
-                        to: Any(
-                            Any {
-                                position: Position {
-                                    path: "",
-                                    line_number: 1,
-                                    column_number: 1,
-                                    line: "",
-                                },
-                            },
-                        ),
-                        argument: None(
-                            None {
-                                position: Position {
-                                    path: "",
-                                    line_number: 1,
-                                    column_number: 1,
-                                    line: "",
-                                },
-                            },
-                        ),
-                        position: Position {
-                            path: "",
-                            line_number: 1,
-                            column_number: 1,
-                            line: "",
-                        },
-                    },
-                ),
-            ],
+                },
+            ),
             position: Position {
                 path: "",
                 line_number: 1,

--- a/lib/hir-mir/src/transformation/snapshots/hir_mir__transformation__map_literal__tests__transform_map_with_entry.snap
+++ b/lib/hir-mir/src/transformation/snapshots/hir_mir__transformation__map_literal__tests__transform_map_with_entry.snap
@@ -3,66 +3,15 @@ source: lib/hir-mir/src/transformation/map_literal.rs
 expression: "transform(&CompileContext::dummy(Default::default(), Default::default()),\n    &Map::new(types::None::new(Position::fake()),\n            types::None::new(Position::fake()),\n            vec![MapEntry ::\n                new(None :: new(Position :: fake()), None ::\n                new(Position :: fake()), Position :: fake()).into()],\n            Position::fake()))"
 ---
 Ok(
-    Call(
-        Call {
-            function_type: Some(
-                Function(
-                    Function {
-                        arguments: [
-                            Reference(
-                                Reference {
-                                    name: "mapContext",
-                                    position: Position {
-                                        path: "",
-                                        line_number: 1,
-                                        column_number: 1,
-                                        line: "",
-                                    },
-                                },
-                            ),
-                            Reference(
-                                Reference {
-                                    name: "GenericMap",
-                                    position: Position {
-                                        path: "",
-                                        line_number: 1,
-                                        column_number: 1,
-                                        line: "",
-                                    },
-                                },
-                            ),
-                            Any(
-                                Any {
-                                    position: Position {
-                                        path: "",
-                                        line_number: 1,
-                                        column_number: 1,
-                                        line: "",
-                                    },
-                                },
-                            ),
-                            Any(
-                                Any {
-                                    position: Position {
-                                        path: "",
-                                        line_number: 1,
-                                        column_number: 1,
-                                        line: "",
-                                    },
-                                },
-                            ),
-                        ],
-                        result: Reference(
-                            Reference {
-                                name: "GenericMap",
-                                position: Position {
-                                    path: "",
-                                    line_number: 1,
-                                    column_number: 1,
-                                    line: "",
-                                },
-                            },
-                        ),
+    Let(
+        Let {
+            name: Some(
+                "$ctx",
+            ),
+            type_: Some(
+                Reference(
+                    Reference {
+                        name: "mapContext",
                         position: Position {
                             path: "",
                             line_number: 1,
@@ -72,9 +21,626 @@ Ok(
                     },
                 ),
             ),
-            function: Variable(
-                Variable {
-                    name: "setMap",
+            bound_expression: Call(
+                Call {
+                    function_type: Some(
+                        Function(
+                            Function {
+                                arguments: [
+                                    Function(
+                                        Function {
+                                            arguments: [
+                                                Any(
+                                                    Any {
+                                                        position: Position {
+                                                            path: "",
+                                                            line_number: 1,
+                                                            column_number: 1,
+                                                            line: "",
+                                                        },
+                                                    },
+                                                ),
+                                                Any(
+                                                    Any {
+                                                        position: Position {
+                                                            path: "",
+                                                            line_number: 1,
+                                                            column_number: 1,
+                                                            line: "",
+                                                        },
+                                                    },
+                                                ),
+                                            ],
+                                            result: Boolean(
+                                                Boolean {
+                                                    position: Position {
+                                                        path: "",
+                                                        line_number: 1,
+                                                        column_number: 1,
+                                                        line: "",
+                                                    },
+                                                },
+                                            ),
+                                            position: Position {
+                                                path: "",
+                                                line_number: 1,
+                                                column_number: 1,
+                                                line: "",
+                                            },
+                                        },
+                                    ),
+                                    Function(
+                                        Function {
+                                            arguments: [
+                                                Any(
+                                                    Any {
+                                                        position: Position {
+                                                            path: "",
+                                                            line_number: 1,
+                                                            column_number: 1,
+                                                            line: "",
+                                                        },
+                                                    },
+                                                ),
+                                            ],
+                                            result: Number(
+                                                Number {
+                                                    position: Position {
+                                                        path: "",
+                                                        line_number: 1,
+                                                        column_number: 1,
+                                                        line: "",
+                                                    },
+                                                },
+                                            ),
+                                            position: Position {
+                                                path: "",
+                                                line_number: 1,
+                                                column_number: 1,
+                                                line: "",
+                                            },
+                                        },
+                                    ),
+                                    Function(
+                                        Function {
+                                            arguments: [
+                                                Any(
+                                                    Any {
+                                                        position: Position {
+                                                            path: "",
+                                                            line_number: 1,
+                                                            column_number: 1,
+                                                            line: "",
+                                                        },
+                                                    },
+                                                ),
+                                                Any(
+                                                    Any {
+                                                        position: Position {
+                                                            path: "",
+                                                            line_number: 1,
+                                                            column_number: 1,
+                                                            line: "",
+                                                        },
+                                                    },
+                                                ),
+                                            ],
+                                            result: Boolean(
+                                                Boolean {
+                                                    position: Position {
+                                                        path: "",
+                                                        line_number: 1,
+                                                        column_number: 1,
+                                                        line: "",
+                                                    },
+                                                },
+                                            ),
+                                            position: Position {
+                                                path: "",
+                                                line_number: 1,
+                                                column_number: 1,
+                                                line: "",
+                                            },
+                                        },
+                                    ),
+                                    Function(
+                                        Function {
+                                            arguments: [
+                                                Any(
+                                                    Any {
+                                                        position: Position {
+                                                            path: "",
+                                                            line_number: 1,
+                                                            column_number: 1,
+                                                            line: "",
+                                                        },
+                                                    },
+                                                ),
+                                            ],
+                                            result: Number(
+                                                Number {
+                                                    position: Position {
+                                                        path: "",
+                                                        line_number: 1,
+                                                        column_number: 1,
+                                                        line: "",
+                                                    },
+                                                },
+                                            ),
+                                            position: Position {
+                                                path: "",
+                                                line_number: 1,
+                                                column_number: 1,
+                                                line: "",
+                                            },
+                                        },
+                                    ),
+                                ],
+                                result: Reference(
+                                    Reference {
+                                        name: "mapContext",
+                                        position: Position {
+                                            path: "",
+                                            line_number: 1,
+                                            column_number: 1,
+                                            line: "",
+                                        },
+                                    },
+                                ),
+                                position: Position {
+                                    path: "",
+                                    line_number: 1,
+                                    column_number: 1,
+                                    line: "",
+                                },
+                            },
+                        ),
+                    ),
+                    function: Variable(
+                        Variable {
+                            name: "newMapContext",
+                            position: Position {
+                                path: "",
+                                line_number: 1,
+                                column_number: 1,
+                                line: "",
+                            },
+                        },
+                    ),
+                    arguments: [
+                        Lambda(
+                            Lambda {
+                                arguments: [
+                                    Argument {
+                                        name: "$lhs",
+                                        type_: Any(
+                                            Any {
+                                                position: Position {
+                                                    path: "",
+                                                    line_number: 1,
+                                                    column_number: 1,
+                                                    line: "",
+                                                },
+                                            },
+                                        ),
+                                    },
+                                    Argument {
+                                        name: "$rhs",
+                                        type_: Any(
+                                            Any {
+                                                position: Position {
+                                                    path: "",
+                                                    line_number: 1,
+                                                    column_number: 1,
+                                                    line: "",
+                                                },
+                                            },
+                                        ),
+                                    },
+                                ],
+                                result_type: Boolean(
+                                    Boolean {
+                                        position: Position {
+                                            path: "",
+                                            line_number: 1,
+                                            column_number: 1,
+                                            line: "",
+                                        },
+                                    },
+                                ),
+                                body: IfType(
+                                    IfType {
+                                        name: "$lhs",
+                                        argument: Variable(
+                                            Variable {
+                                                name: "$lhs",
+                                                position: Position {
+                                                    path: "",
+                                                    line_number: 1,
+                                                    column_number: 1,
+                                                    line: "",
+                                                },
+                                            },
+                                        ),
+                                        branches: [
+                                            IfTypeBranch {
+                                                type_: None(
+                                                    None {
+                                                        position: Position {
+                                                            path: "",
+                                                            line_number: 1,
+                                                            column_number: 1,
+                                                            line: "",
+                                                        },
+                                                    },
+                                                ),
+                                                expression: IfType(
+                                                    IfType {
+                                                        name: "$rhs",
+                                                        argument: Variable(
+                                                            Variable {
+                                                                name: "$rhs",
+                                                                position: Position {
+                                                                    path: "",
+                                                                    line_number: 1,
+                                                                    column_number: 1,
+                                                                    line: "",
+                                                                },
+                                                            },
+                                                        ),
+                                                        branches: [
+                                                            IfTypeBranch {
+                                                                type_: None(
+                                                                    None {
+                                                                        position: Position {
+                                                                            path: "",
+                                                                            line_number: 1,
+                                                                            column_number: 1,
+                                                                            line: "",
+                                                                        },
+                                                                    },
+                                                                ),
+                                                                expression: Boolean(
+                                                                    Boolean {
+                                                                        value: true,
+                                                                        position: Position {
+                                                                            path: "",
+                                                                            line_number: 1,
+                                                                            column_number: 1,
+                                                                            line: "",
+                                                                        },
+                                                                    },
+                                                                ),
+                                                            },
+                                                        ],
+                                                        else_: None,
+                                                        position: Position {
+                                                            path: "",
+                                                            line_number: 1,
+                                                            column_number: 1,
+                                                            line: "",
+                                                        },
+                                                    },
+                                                ),
+                                            },
+                                        ],
+                                        else_: None,
+                                        position: Position {
+                                            path: "",
+                                            line_number: 1,
+                                            column_number: 1,
+                                            line: "",
+                                        },
+                                    },
+                                ),
+                                position: Position {
+                                    path: "",
+                                    line_number: 1,
+                                    column_number: 1,
+                                    line: "",
+                                },
+                            },
+                        ),
+                        Lambda(
+                            Lambda {
+                                arguments: [
+                                    Argument {
+                                        name: "$x",
+                                        type_: Any(
+                                            Any {
+                                                position: Position {
+                                                    path: "",
+                                                    line_number: 1,
+                                                    column_number: 1,
+                                                    line: "",
+                                                },
+                                            },
+                                        ),
+                                    },
+                                ],
+                                result_type: Number(
+                                    Number {
+                                        position: Position {
+                                            path: "",
+                                            line_number: 1,
+                                            column_number: 1,
+                                            line: "",
+                                        },
+                                    },
+                                ),
+                                body: IfType(
+                                    IfType {
+                                        name: "$x",
+                                        argument: Variable(
+                                            Variable {
+                                                name: "$x",
+                                                position: Position {
+                                                    path: "",
+                                                    line_number: 1,
+                                                    column_number: 1,
+                                                    line: "",
+                                                },
+                                            },
+                                        ),
+                                        branches: [
+                                            IfTypeBranch {
+                                                type_: None(
+                                                    None {
+                                                        position: Position {
+                                                            path: "",
+                                                            line_number: 1,
+                                                            column_number: 1,
+                                                            line: "",
+                                                        },
+                                                    },
+                                                ),
+                                                expression: Number(
+                                                    Number {
+                                                        value: 0.0,
+                                                        position: Position {
+                                                            path: "",
+                                                            line_number: 1,
+                                                            column_number: 1,
+                                                            line: "",
+                                                        },
+                                                    },
+                                                ),
+                                            },
+                                        ],
+                                        else_: None,
+                                        position: Position {
+                                            path: "",
+                                            line_number: 1,
+                                            column_number: 1,
+                                            line: "",
+                                        },
+                                    },
+                                ),
+                                position: Position {
+                                    path: "",
+                                    line_number: 1,
+                                    column_number: 1,
+                                    line: "",
+                                },
+                            },
+                        ),
+                        Lambda(
+                            Lambda {
+                                arguments: [
+                                    Argument {
+                                        name: "$lhs",
+                                        type_: Any(
+                                            Any {
+                                                position: Position {
+                                                    path: "",
+                                                    line_number: 1,
+                                                    column_number: 1,
+                                                    line: "",
+                                                },
+                                            },
+                                        ),
+                                    },
+                                    Argument {
+                                        name: "$rhs",
+                                        type_: Any(
+                                            Any {
+                                                position: Position {
+                                                    path: "",
+                                                    line_number: 1,
+                                                    column_number: 1,
+                                                    line: "",
+                                                },
+                                            },
+                                        ),
+                                    },
+                                ],
+                                result_type: Boolean(
+                                    Boolean {
+                                        position: Position {
+                                            path: "",
+                                            line_number: 1,
+                                            column_number: 1,
+                                            line: "",
+                                        },
+                                    },
+                                ),
+                                body: IfType(
+                                    IfType {
+                                        name: "$lhs",
+                                        argument: Variable(
+                                            Variable {
+                                                name: "$lhs",
+                                                position: Position {
+                                                    path: "",
+                                                    line_number: 1,
+                                                    column_number: 1,
+                                                    line: "",
+                                                },
+                                            },
+                                        ),
+                                        branches: [
+                                            IfTypeBranch {
+                                                type_: None(
+                                                    None {
+                                                        position: Position {
+                                                            path: "",
+                                                            line_number: 1,
+                                                            column_number: 1,
+                                                            line: "",
+                                                        },
+                                                    },
+                                                ),
+                                                expression: IfType(
+                                                    IfType {
+                                                        name: "$rhs",
+                                                        argument: Variable(
+                                                            Variable {
+                                                                name: "$rhs",
+                                                                position: Position {
+                                                                    path: "",
+                                                                    line_number: 1,
+                                                                    column_number: 1,
+                                                                    line: "",
+                                                                },
+                                                            },
+                                                        ),
+                                                        branches: [
+                                                            IfTypeBranch {
+                                                                type_: None(
+                                                                    None {
+                                                                        position: Position {
+                                                                            path: "",
+                                                                            line_number: 1,
+                                                                            column_number: 1,
+                                                                            line: "",
+                                                                        },
+                                                                    },
+                                                                ),
+                                                                expression: Boolean(
+                                                                    Boolean {
+                                                                        value: true,
+                                                                        position: Position {
+                                                                            path: "",
+                                                                            line_number: 1,
+                                                                            column_number: 1,
+                                                                            line: "",
+                                                                        },
+                                                                    },
+                                                                ),
+                                                            },
+                                                        ],
+                                                        else_: None,
+                                                        position: Position {
+                                                            path: "",
+                                                            line_number: 1,
+                                                            column_number: 1,
+                                                            line: "",
+                                                        },
+                                                    },
+                                                ),
+                                            },
+                                        ],
+                                        else_: None,
+                                        position: Position {
+                                            path: "",
+                                            line_number: 1,
+                                            column_number: 1,
+                                            line: "",
+                                        },
+                                    },
+                                ),
+                                position: Position {
+                                    path: "",
+                                    line_number: 1,
+                                    column_number: 1,
+                                    line: "",
+                                },
+                            },
+                        ),
+                        Lambda(
+                            Lambda {
+                                arguments: [
+                                    Argument {
+                                        name: "$x",
+                                        type_: Any(
+                                            Any {
+                                                position: Position {
+                                                    path: "",
+                                                    line_number: 1,
+                                                    column_number: 1,
+                                                    line: "",
+                                                },
+                                            },
+                                        ),
+                                    },
+                                ],
+                                result_type: Number(
+                                    Number {
+                                        position: Position {
+                                            path: "",
+                                            line_number: 1,
+                                            column_number: 1,
+                                            line: "",
+                                        },
+                                    },
+                                ),
+                                body: IfType(
+                                    IfType {
+                                        name: "$x",
+                                        argument: Variable(
+                                            Variable {
+                                                name: "$x",
+                                                position: Position {
+                                                    path: "",
+                                                    line_number: 1,
+                                                    column_number: 1,
+                                                    line: "",
+                                                },
+                                            },
+                                        ),
+                                        branches: [
+                                            IfTypeBranch {
+                                                type_: None(
+                                                    None {
+                                                        position: Position {
+                                                            path: "",
+                                                            line_number: 1,
+                                                            column_number: 1,
+                                                            line: "",
+                                                        },
+                                                    },
+                                                ),
+                                                expression: Number(
+                                                    Number {
+                                                        value: 0.0,
+                                                        position: Position {
+                                                            path: "",
+                                                            line_number: 1,
+                                                            column_number: 1,
+                                                            line: "",
+                                                        },
+                                                    },
+                                                ),
+                                            },
+                                        ],
+                                        else_: None,
+                                        position: Position {
+                                            path: "",
+                                            line_number: 1,
+                                            column_number: 1,
+                                            line: "",
+                                        },
+                                    },
+                                ),
+                                position: Position {
+                                    path: "",
+                                    line_number: 1,
+                                    column_number: 1,
+                                    line: "",
+                                },
+                            },
+                        ),
+                    ],
                     position: Position {
                         path: "",
                         line_number: 1,
@@ -83,163 +649,13 @@ Ok(
                     },
                 },
             ),
-            arguments: [
-                Call(
-                    Call {
-                        function_type: Some(
-                            Function(
-                                Function {
-                                    arguments: [
-                                        Function(
-                                            Function {
-                                                arguments: [
-                                                    Any(
-                                                        Any {
-                                                            position: Position {
-                                                                path: "",
-                                                                line_number: 1,
-                                                                column_number: 1,
-                                                                line: "",
-                                                            },
-                                                        },
-                                                    ),
-                                                    Any(
-                                                        Any {
-                                                            position: Position {
-                                                                path: "",
-                                                                line_number: 1,
-                                                                column_number: 1,
-                                                                line: "",
-                                                            },
-                                                        },
-                                                    ),
-                                                ],
-                                                result: Boolean(
-                                                    Boolean {
-                                                        position: Position {
-                                                            path: "",
-                                                            line_number: 1,
-                                                            column_number: 1,
-                                                            line: "",
-                                                        },
-                                                    },
-                                                ),
-                                                position: Position {
-                                                    path: "",
-                                                    line_number: 1,
-                                                    column_number: 1,
-                                                    line: "",
-                                                },
-                                            },
-                                        ),
-                                        Function(
-                                            Function {
-                                                arguments: [
-                                                    Any(
-                                                        Any {
-                                                            position: Position {
-                                                                path: "",
-                                                                line_number: 1,
-                                                                column_number: 1,
-                                                                line: "",
-                                                            },
-                                                        },
-                                                    ),
-                                                ],
-                                                result: Number(
-                                                    Number {
-                                                        position: Position {
-                                                            path: "",
-                                                            line_number: 1,
-                                                            column_number: 1,
-                                                            line: "",
-                                                        },
-                                                    },
-                                                ),
-                                                position: Position {
-                                                    path: "",
-                                                    line_number: 1,
-                                                    column_number: 1,
-                                                    line: "",
-                                                },
-                                            },
-                                        ),
-                                        Function(
-                                            Function {
-                                                arguments: [
-                                                    Any(
-                                                        Any {
-                                                            position: Position {
-                                                                path: "",
-                                                                line_number: 1,
-                                                                column_number: 1,
-                                                                line: "",
-                                                            },
-                                                        },
-                                                    ),
-                                                    Any(
-                                                        Any {
-                                                            position: Position {
-                                                                path: "",
-                                                                line_number: 1,
-                                                                column_number: 1,
-                                                                line: "",
-                                                            },
-                                                        },
-                                                    ),
-                                                ],
-                                                result: Boolean(
-                                                    Boolean {
-                                                        position: Position {
-                                                            path: "",
-                                                            line_number: 1,
-                                                            column_number: 1,
-                                                            line: "",
-                                                        },
-                                                    },
-                                                ),
-                                                position: Position {
-                                                    path: "",
-                                                    line_number: 1,
-                                                    column_number: 1,
-                                                    line: "",
-                                                },
-                                            },
-                                        ),
-                                        Function(
-                                            Function {
-                                                arguments: [
-                                                    Any(
-                                                        Any {
-                                                            position: Position {
-                                                                path: "",
-                                                                line_number: 1,
-                                                                column_number: 1,
-                                                                line: "",
-                                                            },
-                                                        },
-                                                    ),
-                                                ],
-                                                result: Number(
-                                                    Number {
-                                                        position: Position {
-                                                            path: "",
-                                                            line_number: 1,
-                                                            column_number: 1,
-                                                            line: "",
-                                                        },
-                                                    },
-                                                ),
-                                                position: Position {
-                                                    path: "",
-                                                    line_number: 1,
-                                                    column_number: 1,
-                                                    line: "",
-                                                },
-                                            },
-                                        ),
-                                    ],
-                                    result: Reference(
+            expression: Call(
+                Call {
+                    function_type: Some(
+                        Function(
+                            Function {
+                                arguments: [
+                                    Reference(
                                         Reference {
                                             name: "mapContext",
                                             position: Position {
@@ -250,475 +666,7 @@ Ok(
                                             },
                                         },
                                     ),
-                                    position: Position {
-                                        path: "",
-                                        line_number: 1,
-                                        column_number: 1,
-                                        line: "",
-                                    },
-                                },
-                            ),
-                        ),
-                        function: Variable(
-                            Variable {
-                                name: "newMapContext",
-                                position: Position {
-                                    path: "",
-                                    line_number: 1,
-                                    column_number: 1,
-                                    line: "",
-                                },
-                            },
-                        ),
-                        arguments: [
-                            Lambda(
-                                Lambda {
-                                    arguments: [
-                                        Argument {
-                                            name: "$lhs",
-                                            type_: Any(
-                                                Any {
-                                                    position: Position {
-                                                        path: "",
-                                                        line_number: 1,
-                                                        column_number: 1,
-                                                        line: "",
-                                                    },
-                                                },
-                                            ),
-                                        },
-                                        Argument {
-                                            name: "$rhs",
-                                            type_: Any(
-                                                Any {
-                                                    position: Position {
-                                                        path: "",
-                                                        line_number: 1,
-                                                        column_number: 1,
-                                                        line: "",
-                                                    },
-                                                },
-                                            ),
-                                        },
-                                    ],
-                                    result_type: Boolean(
-                                        Boolean {
-                                            position: Position {
-                                                path: "",
-                                                line_number: 1,
-                                                column_number: 1,
-                                                line: "",
-                                            },
-                                        },
-                                    ),
-                                    body: IfType(
-                                        IfType {
-                                            name: "$lhs",
-                                            argument: Variable(
-                                                Variable {
-                                                    name: "$lhs",
-                                                    position: Position {
-                                                        path: "",
-                                                        line_number: 1,
-                                                        column_number: 1,
-                                                        line: "",
-                                                    },
-                                                },
-                                            ),
-                                            branches: [
-                                                IfTypeBranch {
-                                                    type_: None(
-                                                        None {
-                                                            position: Position {
-                                                                path: "",
-                                                                line_number: 1,
-                                                                column_number: 1,
-                                                                line: "",
-                                                            },
-                                                        },
-                                                    ),
-                                                    expression: IfType(
-                                                        IfType {
-                                                            name: "$rhs",
-                                                            argument: Variable(
-                                                                Variable {
-                                                                    name: "$rhs",
-                                                                    position: Position {
-                                                                        path: "",
-                                                                        line_number: 1,
-                                                                        column_number: 1,
-                                                                        line: "",
-                                                                    },
-                                                                },
-                                                            ),
-                                                            branches: [
-                                                                IfTypeBranch {
-                                                                    type_: None(
-                                                                        None {
-                                                                            position: Position {
-                                                                                path: "",
-                                                                                line_number: 1,
-                                                                                column_number: 1,
-                                                                                line: "",
-                                                                            },
-                                                                        },
-                                                                    ),
-                                                                    expression: Boolean(
-                                                                        Boolean {
-                                                                            value: true,
-                                                                            position: Position {
-                                                                                path: "",
-                                                                                line_number: 1,
-                                                                                column_number: 1,
-                                                                                line: "",
-                                                                            },
-                                                                        },
-                                                                    ),
-                                                                },
-                                                            ],
-                                                            else_: None,
-                                                            position: Position {
-                                                                path: "",
-                                                                line_number: 1,
-                                                                column_number: 1,
-                                                                line: "",
-                                                            },
-                                                        },
-                                                    ),
-                                                },
-                                            ],
-                                            else_: None,
-                                            position: Position {
-                                                path: "",
-                                                line_number: 1,
-                                                column_number: 1,
-                                                line: "",
-                                            },
-                                        },
-                                    ),
-                                    position: Position {
-                                        path: "",
-                                        line_number: 1,
-                                        column_number: 1,
-                                        line: "",
-                                    },
-                                },
-                            ),
-                            Lambda(
-                                Lambda {
-                                    arguments: [
-                                        Argument {
-                                            name: "$x",
-                                            type_: Any(
-                                                Any {
-                                                    position: Position {
-                                                        path: "",
-                                                        line_number: 1,
-                                                        column_number: 1,
-                                                        line: "",
-                                                    },
-                                                },
-                                            ),
-                                        },
-                                    ],
-                                    result_type: Number(
-                                        Number {
-                                            position: Position {
-                                                path: "",
-                                                line_number: 1,
-                                                column_number: 1,
-                                                line: "",
-                                            },
-                                        },
-                                    ),
-                                    body: IfType(
-                                        IfType {
-                                            name: "$x",
-                                            argument: Variable(
-                                                Variable {
-                                                    name: "$x",
-                                                    position: Position {
-                                                        path: "",
-                                                        line_number: 1,
-                                                        column_number: 1,
-                                                        line: "",
-                                                    },
-                                                },
-                                            ),
-                                            branches: [
-                                                IfTypeBranch {
-                                                    type_: None(
-                                                        None {
-                                                            position: Position {
-                                                                path: "",
-                                                                line_number: 1,
-                                                                column_number: 1,
-                                                                line: "",
-                                                            },
-                                                        },
-                                                    ),
-                                                    expression: Number(
-                                                        Number {
-                                                            value: 0.0,
-                                                            position: Position {
-                                                                path: "",
-                                                                line_number: 1,
-                                                                column_number: 1,
-                                                                line: "",
-                                                            },
-                                                        },
-                                                    ),
-                                                },
-                                            ],
-                                            else_: None,
-                                            position: Position {
-                                                path: "",
-                                                line_number: 1,
-                                                column_number: 1,
-                                                line: "",
-                                            },
-                                        },
-                                    ),
-                                    position: Position {
-                                        path: "",
-                                        line_number: 1,
-                                        column_number: 1,
-                                        line: "",
-                                    },
-                                },
-                            ),
-                            Lambda(
-                                Lambda {
-                                    arguments: [
-                                        Argument {
-                                            name: "$lhs",
-                                            type_: Any(
-                                                Any {
-                                                    position: Position {
-                                                        path: "",
-                                                        line_number: 1,
-                                                        column_number: 1,
-                                                        line: "",
-                                                    },
-                                                },
-                                            ),
-                                        },
-                                        Argument {
-                                            name: "$rhs",
-                                            type_: Any(
-                                                Any {
-                                                    position: Position {
-                                                        path: "",
-                                                        line_number: 1,
-                                                        column_number: 1,
-                                                        line: "",
-                                                    },
-                                                },
-                                            ),
-                                        },
-                                    ],
-                                    result_type: Boolean(
-                                        Boolean {
-                                            position: Position {
-                                                path: "",
-                                                line_number: 1,
-                                                column_number: 1,
-                                                line: "",
-                                            },
-                                        },
-                                    ),
-                                    body: IfType(
-                                        IfType {
-                                            name: "$lhs",
-                                            argument: Variable(
-                                                Variable {
-                                                    name: "$lhs",
-                                                    position: Position {
-                                                        path: "",
-                                                        line_number: 1,
-                                                        column_number: 1,
-                                                        line: "",
-                                                    },
-                                                },
-                                            ),
-                                            branches: [
-                                                IfTypeBranch {
-                                                    type_: None(
-                                                        None {
-                                                            position: Position {
-                                                                path: "",
-                                                                line_number: 1,
-                                                                column_number: 1,
-                                                                line: "",
-                                                            },
-                                                        },
-                                                    ),
-                                                    expression: IfType(
-                                                        IfType {
-                                                            name: "$rhs",
-                                                            argument: Variable(
-                                                                Variable {
-                                                                    name: "$rhs",
-                                                                    position: Position {
-                                                                        path: "",
-                                                                        line_number: 1,
-                                                                        column_number: 1,
-                                                                        line: "",
-                                                                    },
-                                                                },
-                                                            ),
-                                                            branches: [
-                                                                IfTypeBranch {
-                                                                    type_: None(
-                                                                        None {
-                                                                            position: Position {
-                                                                                path: "",
-                                                                                line_number: 1,
-                                                                                column_number: 1,
-                                                                                line: "",
-                                                                            },
-                                                                        },
-                                                                    ),
-                                                                    expression: Boolean(
-                                                                        Boolean {
-                                                                            value: true,
-                                                                            position: Position {
-                                                                                path: "",
-                                                                                line_number: 1,
-                                                                                column_number: 1,
-                                                                                line: "",
-                                                                            },
-                                                                        },
-                                                                    ),
-                                                                },
-                                                            ],
-                                                            else_: None,
-                                                            position: Position {
-                                                                path: "",
-                                                                line_number: 1,
-                                                                column_number: 1,
-                                                                line: "",
-                                                            },
-                                                        },
-                                                    ),
-                                                },
-                                            ],
-                                            else_: None,
-                                            position: Position {
-                                                path: "",
-                                                line_number: 1,
-                                                column_number: 1,
-                                                line: "",
-                                            },
-                                        },
-                                    ),
-                                    position: Position {
-                                        path: "",
-                                        line_number: 1,
-                                        column_number: 1,
-                                        line: "",
-                                    },
-                                },
-                            ),
-                            Lambda(
-                                Lambda {
-                                    arguments: [
-                                        Argument {
-                                            name: "$x",
-                                            type_: Any(
-                                                Any {
-                                                    position: Position {
-                                                        path: "",
-                                                        line_number: 1,
-                                                        column_number: 1,
-                                                        line: "",
-                                                    },
-                                                },
-                                            ),
-                                        },
-                                    ],
-                                    result_type: Number(
-                                        Number {
-                                            position: Position {
-                                                path: "",
-                                                line_number: 1,
-                                                column_number: 1,
-                                                line: "",
-                                            },
-                                        },
-                                    ),
-                                    body: IfType(
-                                        IfType {
-                                            name: "$x",
-                                            argument: Variable(
-                                                Variable {
-                                                    name: "$x",
-                                                    position: Position {
-                                                        path: "",
-                                                        line_number: 1,
-                                                        column_number: 1,
-                                                        line: "",
-                                                    },
-                                                },
-                                            ),
-                                            branches: [
-                                                IfTypeBranch {
-                                                    type_: None(
-                                                        None {
-                                                            position: Position {
-                                                                path: "",
-                                                                line_number: 1,
-                                                                column_number: 1,
-                                                                line: "",
-                                                            },
-                                                        },
-                                                    ),
-                                                    expression: Number(
-                                                        Number {
-                                                            value: 0.0,
-                                                            position: Position {
-                                                                path: "",
-                                                                line_number: 1,
-                                                                column_number: 1,
-                                                                line: "",
-                                                            },
-                                                        },
-                                                    ),
-                                                },
-                                            ],
-                                            else_: None,
-                                            position: Position {
-                                                path: "",
-                                                line_number: 1,
-                                                column_number: 1,
-                                                line: "",
-                                            },
-                                        },
-                                    ),
-                                    position: Position {
-                                        path: "",
-                                        line_number: 1,
-                                        column_number: 1,
-                                        line: "",
-                                    },
-                                },
-                            ),
-                        ],
-                        position: Position {
-                            path: "",
-                            line_number: 1,
-                            column_number: 1,
-                            line: "",
-                        },
-                    },
-                ),
-                Call(
-                    Call {
-                        function_type: Some(
-                            Function(
-                                Function {
-                                    arguments: [],
-                                    result: Reference(
+                                    Reference(
                                         Reference {
                                             name: "GenericMap",
                                             position: Position {
@@ -729,18 +677,62 @@ Ok(
                                             },
                                         },
                                     ),
-                                    position: Position {
-                                        path: "",
-                                        line_number: 1,
-                                        column_number: 1,
-                                        line: "",
+                                    Any(
+                                        Any {
+                                            position: Position {
+                                                path: "",
+                                                line_number: 1,
+                                                column_number: 1,
+                                                line: "",
+                                            },
+                                        },
+                                    ),
+                                    Any(
+                                        Any {
+                                            position: Position {
+                                                path: "",
+                                                line_number: 1,
+                                                column_number: 1,
+                                                line: "",
+                                            },
+                                        },
+                                    ),
+                                ],
+                                result: Reference(
+                                    Reference {
+                                        name: "GenericMap",
+                                        position: Position {
+                                            path: "",
+                                            line_number: 1,
+                                            column_number: 1,
+                                            line: "",
+                                        },
                                     },
+                                ),
+                                position: Position {
+                                    path: "",
+                                    line_number: 1,
+                                    column_number: 1,
+                                    line: "",
                                 },
-                            ),
+                            },
                         ),
-                        function: Variable(
+                    ),
+                    function: Variable(
+                        Variable {
+                            name: "setMap",
+                            position: Position {
+                                path: "",
+                                line_number: 1,
+                                column_number: 1,
+                                line: "",
+                            },
+                        },
+                    ),
+                    arguments: [
+                        Variable(
                             Variable {
-                                name: "emptyMap",
+                                name: "$ctx",
                                 position: Position {
                                     path: "",
                                     line_number: 1,
@@ -749,96 +741,141 @@ Ok(
                                 },
                             },
                         ),
-                        arguments: [],
-                        position: Position {
-                            path: "",
-                            line_number: 1,
-                            column_number: 1,
-                            line: "",
-                        },
+                        Call(
+                            Call {
+                                function_type: Some(
+                                    Function(
+                                        Function {
+                                            arguments: [],
+                                            result: Reference(
+                                                Reference {
+                                                    name: "GenericMap",
+                                                    position: Position {
+                                                        path: "",
+                                                        line_number: 1,
+                                                        column_number: 1,
+                                                        line: "",
+                                                    },
+                                                },
+                                            ),
+                                            position: Position {
+                                                path: "",
+                                                line_number: 1,
+                                                column_number: 1,
+                                                line: "",
+                                            },
+                                        },
+                                    ),
+                                ),
+                                function: Variable(
+                                    Variable {
+                                        name: "emptyMap",
+                                        position: Position {
+                                            path: "",
+                                            line_number: 1,
+                                            column_number: 1,
+                                            line: "",
+                                        },
+                                    },
+                                ),
+                                arguments: [],
+                                position: Position {
+                                    path: "",
+                                    line_number: 1,
+                                    column_number: 1,
+                                    line: "",
+                                },
+                            },
+                        ),
+                        TypeCoercion(
+                            TypeCoercion {
+                                from: None(
+                                    None {
+                                        position: Position {
+                                            path: "",
+                                            line_number: 1,
+                                            column_number: 1,
+                                            line: "",
+                                        },
+                                    },
+                                ),
+                                to: Any(
+                                    Any {
+                                        position: Position {
+                                            path: "",
+                                            line_number: 1,
+                                            column_number: 1,
+                                            line: "",
+                                        },
+                                    },
+                                ),
+                                argument: None(
+                                    None {
+                                        position: Position {
+                                            path: "",
+                                            line_number: 1,
+                                            column_number: 1,
+                                            line: "",
+                                        },
+                                    },
+                                ),
+                                position: Position {
+                                    path: "",
+                                    line_number: 1,
+                                    column_number: 1,
+                                    line: "",
+                                },
+                            },
+                        ),
+                        TypeCoercion(
+                            TypeCoercion {
+                                from: None(
+                                    None {
+                                        position: Position {
+                                            path: "",
+                                            line_number: 1,
+                                            column_number: 1,
+                                            line: "",
+                                        },
+                                    },
+                                ),
+                                to: Any(
+                                    Any {
+                                        position: Position {
+                                            path: "",
+                                            line_number: 1,
+                                            column_number: 1,
+                                            line: "",
+                                        },
+                                    },
+                                ),
+                                argument: None(
+                                    None {
+                                        position: Position {
+                                            path: "",
+                                            line_number: 1,
+                                            column_number: 1,
+                                            line: "",
+                                        },
+                                    },
+                                ),
+                                position: Position {
+                                    path: "",
+                                    line_number: 1,
+                                    column_number: 1,
+                                    line: "",
+                                },
+                            },
+                        ),
+                    ],
+                    position: Position {
+                        path: "",
+                        line_number: 1,
+                        column_number: 1,
+                        line: "",
                     },
-                ),
-                TypeCoercion(
-                    TypeCoercion {
-                        from: None(
-                            None {
-                                position: Position {
-                                    path: "",
-                                    line_number: 1,
-                                    column_number: 1,
-                                    line: "",
-                                },
-                            },
-                        ),
-                        to: Any(
-                            Any {
-                                position: Position {
-                                    path: "",
-                                    line_number: 1,
-                                    column_number: 1,
-                                    line: "",
-                                },
-                            },
-                        ),
-                        argument: None(
-                            None {
-                                position: Position {
-                                    path: "",
-                                    line_number: 1,
-                                    column_number: 1,
-                                    line: "",
-                                },
-                            },
-                        ),
-                        position: Position {
-                            path: "",
-                            line_number: 1,
-                            column_number: 1,
-                            line: "",
-                        },
-                    },
-                ),
-                TypeCoercion(
-                    TypeCoercion {
-                        from: None(
-                            None {
-                                position: Position {
-                                    path: "",
-                                    line_number: 1,
-                                    column_number: 1,
-                                    line: "",
-                                },
-                            },
-                        ),
-                        to: Any(
-                            Any {
-                                position: Position {
-                                    path: "",
-                                    line_number: 1,
-                                    column_number: 1,
-                                    line: "",
-                                },
-                            },
-                        ),
-                        argument: None(
-                            None {
-                                position: Position {
-                                    path: "",
-                                    line_number: 1,
-                                    column_number: 1,
-                                    line: "",
-                                },
-                            },
-                        ),
-                        position: Position {
-                            path: "",
-                            line_number: 1,
-                            column_number: 1,
-                            line: "",
-                        },
-                    },
-                ),
-            ],
+                },
+            ),
             position: Position {
                 path: "",
                 line_number: 1,

--- a/lib/hir-mir/src/transformation/snapshots/hir_mir__transformation__map_literal__tests__transform_map_with_spread_map.snap
+++ b/lib/hir-mir/src/transformation/snapshots/hir_mir__transformation__map_literal__tests__transform_map_with_spread_map.snap
@@ -1,6 +1,6 @@
 ---
 source: lib/hir-mir/src/transformation/map_literal.rs
-expression: "transform(&CompileContext::dummy(Default::default(), Default::default()),\n    &Map::new(types::None::new(Position::fake()),\n            types::None::new(Position::fake()), vec![], Position::fake()))"
+expression: "transform(&CompileContext::dummy(Default::default(), Default::default()),\n    &Map::new(types::None::new(Position::fake()),\n            types::None::new(Position::fake()),\n            vec![MapElement :: Map(None :: new(Position :: fake()).into())],\n            Position::fake()))"
 ---
 Ok(
     Let(
@@ -649,44 +649,8 @@ Ok(
                     },
                 },
             ),
-            expression: Call(
-                Call {
-                    function_type: Some(
-                        Function(
-                            Function {
-                                arguments: [],
-                                result: Reference(
-                                    Reference {
-                                        name: "GenericMap",
-                                        position: Position {
-                                            path: "",
-                                            line_number: 1,
-                                            column_number: 1,
-                                            line: "",
-                                        },
-                                    },
-                                ),
-                                position: Position {
-                                    path: "",
-                                    line_number: 1,
-                                    column_number: 1,
-                                    line: "",
-                                },
-                            },
-                        ),
-                    ),
-                    function: Variable(
-                        Variable {
-                            name: "emptyMap",
-                            position: Position {
-                                path: "",
-                                line_number: 1,
-                                column_number: 1,
-                                line: "",
-                            },
-                        },
-                    ),
-                    arguments: [],
+            expression: None(
+                None {
                     position: Position {
                         path: "",
                         line_number: 1,

--- a/tools/unused_dependencies.sh
+++ b/tools/unused_dependencies.sh
@@ -4,7 +4,7 @@ set -e
 
 . $(dirname $0)/utilities.sh
 
-version=nightly-2022-04-25
+version=nightly-2022-07-17
 
 rustup install $version
 rustup run $version cargo install cargo-udeps


### PR DESCRIPTION
- Solve #1207 partially by reducing the number of map context creation and equal function definitions.