### PR TITLE
Rerun codesign on macOS

### DIFF
--- a/packages/os-sync/pen-link.sh
+++ b/packages/os-sync/pen-link.sh
@@ -58,3 +58,7 @@ if [ -r $binary.wasm ]; then
 fi
 
 cp $binary $output
+
+if [ $(uname) = Darwin ]; then
+  codesign -s - $output
+fi

--- a/packages/os/pen-link.sh
+++ b/packages/os/pen-link.sh
@@ -58,3 +58,7 @@ if [ -r $binary.wasm ]; then
 fi
 
 cp $binary $output
+
+if [ $(uname) = Darwin ]; then
+  codesign -s - $output
+fi


### PR DESCRIPTION
- `cp target/release/os-app ../app` invalidates its code signature while `codesign --verify` works.
- `cp ./app ~/app` again lets the executable run successfully.
- Why???