### PR TITLE
Optimzie reference counting algorithm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,9 +155,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.0.15"
+version = "4.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bf8832993da70a4c6d13c581f4463c2bdda27b9bf1c5498dc4365543abe6d6f"
+checksum = "2ef582e2c00a63a0c0aa1fb4a4870781c4f5729f51196d3537fa7c1c1992eaa3"
 dependencies = [
  "atty",
  "bitflags",
@@ -435,7 +435,7 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 [[package]]
 name = "hamt"
 version = "0.3.1"
-source = "git+https://github.com/raviqqe/hamt-rs?branch=main#34249d59c2871cc4dc96d7583b2998d11ec0a101"
+source = "git+https://github.com/raviqqe/hamt-rs?branch=main#ca3ec8ce8381d1c57608073934081f62e14d92ef"
 
 [[package]]
 name = "hashbrown"

--- a/lib/mir/src/analysis/reference_count/transformation.rs
+++ b/lib/mir/src/analysis/reference_count/transformation.rs
@@ -1,6 +1,6 @@
 use super::error::ReferenceCountError;
 use crate::{ir::*, types::Type};
-use fnv::{FnvHashMap, FnvHashSet};
+use fnv::FnvHashSet;
 
 // Closure environments need to be inferred before reference counting.
 pub fn transform(module: &Module) -> Result<Module, ReferenceCountError> {
@@ -75,9 +75,9 @@ fn transform_function_definition(
 //   in their expressions.
 fn transform_expression(
     expression: &Expression,
-    owned_variables: &FnvHashMap<String, Type>,
-    moved_variables: &FnvHashSet<String>,
-) -> Result<(Expression, FnvHashSet<String>), ReferenceCountError> {
+    owned_variables: &hamt::Map<String, Type>,
+    moved_variables: &hamt::Set<String>,
+) -> Result<(Expression, hamt::Set<String>), ReferenceCountError> {
     Ok(match expression {
         Expression::ArithmeticOperation(operation) => {
             let (rhs, moved_variables) =
@@ -583,7 +583,7 @@ fn transform_expression(
 fn clone_variables(
     expression: impl Into<Expression>,
     cloned_variables: FnvHashSet<String>,
-    owned_variables: &FnvHashMap<String, Type>,
+    owned_variables: &hamt::Map<String, Type>,
 ) -> Expression {
     let expression = expression.into();
 
@@ -605,7 +605,7 @@ fn clone_variables(
 fn drop_variables(
     expression: impl Into<Expression>,
     dropped_variables: FnvHashSet<String>,
-    owned_variables: &FnvHashMap<String, Type>,
+    owned_variables: &hamt::Map<String, Type>,
 ) -> Expression {
     let expression = expression.into();
 
@@ -626,8 +626,8 @@ fn drop_variables(
 
 fn should_clone_variable(
     variable: &str,
-    owned_variables: &FnvHashMap<String, Type>,
-    moved_variables: &FnvHashSet<String>,
+    owned_variables: &hamt::Map<String, Type>,
+    moved_variables: &hamt::Set<String>,
 ) -> bool {
     owned_variables.contains_key(variable) && moved_variables.contains(variable)
 }


### PR DESCRIPTION
# Benchmark

This is actually slower...

```
> hyperfine '~/src/github.com/pen-lang/pen/target/release/pen compile-prelude --target aarch64-apple-darwin /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/packages/pen_prelude/Map.pen /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/objects/Map_eca1efc0cf2dc7fa.bc /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/objects/Map_eca1efc0cf2dc7f' '~/worktree/9bb7fbdcd12a52a3/target/release/pen compile-prelude --target aarch64-apple-darwin /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/packages/pen_prelude/Map.pen /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/objects/Map_eca1efc0cf2dc7fa.bc /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/objects/Map_eca1efc0cf2dc7f'
Benchmark 1: ~/src/github.com/pen-lang/pen/target/release/pen compile-prelude --target aarch64-apple-darwin /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/packages/pen_prelude/Map.pen /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/objects/Map_eca1efc0cf2dc7fa.bc /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/objects/Map_eca1efc0cf2dc7f
  Time (mean ± σ):     214.0 ms ±   0.8 ms    [User: 201.8 ms, System: 10.2 ms]
  Range (min … max):   212.9 ms … 215.6 ms    13 runs

Benchmark 2: ~/worktree/9bb7fbdcd12a52a3/target/release/pen compile-prelude --target aarch64-apple-darwin /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/packages/pen_prelude/Map.pen /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/objects/Map_eca1efc0cf2dc7fa.bc /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/objects/Map_eca1efc0cf2dc7f
  Time (mean ± σ):     216.7 ms ±   0.6 ms    [User: 204.3 ms, System: 10.3 ms]
  Range (min … max):   215.7 ms … 217.6 ms    13 runs

Summary
  '~/src/github.com/pen-lang/pen/target/release/pen compile-prelude --target aarch64-apple-darwin /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/packages/pen_prelude/Map.pen /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/objects/Map_eca1efc0cf2dc7fa.bc /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/objects/Map_eca1efc0cf2dc7f' ran
    1.01 ± 0.00 times faster than '~/worktree/9bb7fbdcd12a52a3/target/release/pen compile-prelude --target aarch64-apple-darwin /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/packages/pen_prelude/Map.pen /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/objects/Map_eca1efc0cf2dc7fa.bc /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/objects/Map_eca1efc0cf2dc7f'
```