### PR TITLE
Cache type compilation from MIR to F--

### DIFF
--- a/lib/mir-fmm/src/context.rs
+++ b/lib/mir-fmm/src/context.rs
@@ -1,9 +1,11 @@
 use crate::configuration::Configuration;
 use fnv::FnvHashMap;
+use std::cell::RefCell;
 
 pub struct Context {
     module_builder: fmm::build::ModuleBuilder,
     types: FnvHashMap<String, mir::types::RecordBody>,
+    fmm_types: RefCell<FnvHashMap<mir::types::Type, fmm::types::Type>>,
     type_information: mir::ir::TypeInformation,
     configuration: Configuration,
 }
@@ -17,6 +19,7 @@ impl Context {
                 .iter()
                 .map(|definition| (definition.name().into(), definition.type_().clone()))
                 .collect(),
+            fmm_types: Default::default(),
             type_information: module.type_information().clone(),
             configuration,
         }
@@ -32,6 +35,10 @@ impl Context {
 
     pub fn type_information(&self) -> &mir::ir::TypeInformation {
         &self.type_information
+    }
+
+    pub fn fmm_types(&self) -> &RefCell<FnvHashMap<mir::types::Type, fmm::types::Type>> {
+        &self.fmm_types
     }
 
     pub fn configuration(&self) -> &Configuration {

--- a/lib/mir-fmm/src/type_.rs
+++ b/lib/mir-fmm/src/type_.rs
@@ -6,7 +6,11 @@ use crate::context::Context;
 pub const FUNCTION_ARGUMENT_OFFSET: usize = 1;
 
 pub fn compile(context: &Context, type_: &mir::types::Type) -> fmm::types::Type {
-    match type_ {
+    if let Some(type_) = context.fmm_types().borrow().get(type_) {
+        return type_.clone();
+    }
+
+    let fmm_type = match type_ {
         mir::types::Type::Boolean => fmm::types::Primitive::Boolean.into(),
         mir::types::Type::Function(function) => compile_function(context, function),
         mir::types::Type::None => compile_none(),
@@ -14,7 +18,14 @@ pub fn compile(context: &Context, type_: &mir::types::Type) -> fmm::types::Type 
         mir::types::Type::Record(record) => compile_record(context, record),
         mir::types::Type::ByteString => compile_string().into(),
         mir::types::Type::Variant => compile_variant().into(),
-    }
+    };
+
+    context
+        .fmm_types()
+        .borrow_mut()
+        .insert(type_.clone(), fmm_type.clone());
+
+    fmm_type
 }
 
 pub fn compile_function(context: &Context, function: &mir::types::Function) -> fmm::types::Type {


### PR DESCRIPTION
# Benchmark

```
> hyperfine -w 10 '~/pen-old compile-prelude --target aarch64-apple-darwin /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/packages/pen_prelude/Map.pen /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/objects/Map_eca1efc0cf2dc7fa.bc /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/objects/Map_eca1efc0cf2dc7f' '~/pen-new compile-prelude --target aarch64-apple-darwin /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/packages/pen_prelude/Map.pen /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/objects/Map_eca1efc0cf2dc7fa.bc /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/objects/Map_eca1efc0cf2dc7f'
Benchmark 1: ~/pen-old compile-prelude --target aarch64-apple-darwin /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/packages/pen_prelude/Map.pen /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/objects/Map_eca1efc0cf2dc7fa.bc /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/objects/Map_eca1efc0cf2dc7f
  Time (mean ± σ):     177.0 ms ±   1.3 ms    [User: 165.3 ms, System: 9.6 ms]
  Range (min … max):   176.1 ms … 180.3 ms    16 runs

Benchmark 2: ~/pen-new compile-prelude --target aarch64-apple-darwin /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/packages/pen_prelude/Map.pen /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/objects/Map_eca1efc0cf2dc7fa.bc /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/objects/Map_eca1efc0cf2dc7f
  Time (mean ± σ):     165.0 ms ±   0.6 ms    [User: 155.2 ms, System: 7.9 ms]
  Range (min … max):   164.0 ms … 166.2 ms    17 runs

Summary
  '~/pen-new compile-prelude --target aarch64-apple-darwin /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/packages/pen_prelude/Map.pen /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/objects/Map_eca1efc0cf2dc7fa.bc /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/objects/Map_eca1efc0cf2dc7f' ran
    1.07 ± 0.01 times faster than '~/pen-old compile-prelude --target aarch64-apple-darwin /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/packages/pen_prelude/Map.pen /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/objects/Map_eca1efc0cf2dc7fa.bc /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/objects/Map_eca1efc0cf2dc7f'
```