### PR TITLE
Optimize HIR type data structure

### DIFF
--- a/lib/hir-mir/src/transformation/equal_operation/snapshots/hir_mir__transformation__equal_operation__module__tests__transform_comparable_type.snap
+++ b/lib/hir-mir/src/transformation/equal_operation/snapshots/hir_mir__transformation__equal_operation__module__tests__transform_comparable_type.snap
@@ -10,33 +10,41 @@ Ok(
                 name: "a",
                 original_name: "",
                 type_: List(
-                    List {
-                        element: None(
-                            None {
-                                position: Position {
+                    List(
+                        ListInner {
+                            element: None(
+                                None {
+                                    position: Position(
+                                        PositionInner {
+                                            path: "",
+                                            line_number: 1,
+                                            column_number: 1,
+                                            line: "",
+                                        },
+                                    ),
+                                },
+                            ),
+                            position: Position(
+                                PositionInner {
                                     path: "",
                                     line_number: 1,
                                     column_number: 1,
                                     line: "",
                                 },
-                            },
-                        ),
-                        position: Position {
-                            path: "",
-                            line_number: 1,
-                            column_number: 1,
-                            line: "",
+                            ),
                         },
-                    },
+                    ),
                 ),
                 public: false,
                 external: false,
-                position: Position {
-                    path: "",
-                    line_number: 1,
-                    column_number: 1,
-                    line: "",
-                },
+                position: Position(
+                    PositionInner {
+                        path: "",
+                        line_number: 1,
+                        column_number: 1,
+                        line: "",
+                    },
+                ),
             },
         ],
         foreign_declarations: [],
@@ -51,12 +59,14 @@ Ok(
                             name: "$lhs",
                             type_: Any(
                                 Any {
-                                    position: Position {
-                                        path: "",
-                                        line_number: 1,
-                                        column_number: 1,
-                                        line: "",
-                                    },
+                                    position: Position(
+                                        PositionInner {
+                                            path: "",
+                                            line_number: 1,
+                                            column_number: 1,
+                                            line: "",
+                                        },
+                                    ),
                                 },
                             ),
                         },
@@ -64,24 +74,28 @@ Ok(
                             name: "$rhs",
                             type_: Any(
                                 Any {
-                                    position: Position {
-                                        path: "",
-                                        line_number: 1,
-                                        column_number: 1,
-                                        line: "",
-                                    },
+                                    position: Position(
+                                        PositionInner {
+                                            path: "",
+                                            line_number: 1,
+                                            column_number: 1,
+                                            line: "",
+                                        },
+                                    ),
                                 },
                             ),
                         },
                     ],
                     result_type: Boolean(
                         Boolean {
-                            position: Position {
-                                path: "",
-                                line_number: 1,
-                                column_number: 1,
-                                line: "",
-                            },
+                            position: Position(
+                                PositionInner {
+                                    path: "",
+                                    line_number: 1,
+                                    column_number: 1,
+                                    line: "",
+                                },
+                            ),
                         },
                     ),
                     body: IfType(
@@ -90,24 +104,28 @@ Ok(
                             argument: Variable(
                                 Variable {
                                     name: "$lhs",
-                                    position: Position {
-                                        path: "",
-                                        line_number: 1,
-                                        column_number: 1,
-                                        line: "",
-                                    },
+                                    position: Position(
+                                        PositionInner {
+                                            path: "",
+                                            line_number: 1,
+                                            column_number: 1,
+                                            line: "",
+                                        },
+                                    ),
                                 },
                             ),
                             branches: [
                                 IfTypeBranch {
                                     type_: None(
                                         None {
-                                            position: Position {
-                                                path: "",
-                                                line_number: 1,
-                                                column_number: 1,
-                                                line: "",
-                                            },
+                                            position: Position(
+                                                PositionInner {
+                                                    path: "",
+                                                    line_number: 1,
+                                                    column_number: 1,
+                                                    line: "",
+                                                },
+                                            ),
                                         },
                                     ),
                                     expression: IfType(
@@ -116,81 +134,97 @@ Ok(
                                             argument: Variable(
                                                 Variable {
                                                     name: "$rhs",
-                                                    position: Position {
-                                                        path: "",
-                                                        line_number: 1,
-                                                        column_number: 1,
-                                                        line: "",
-                                                    },
+                                                    position: Position(
+                                                        PositionInner {
+                                                            path: "",
+                                                            line_number: 1,
+                                                            column_number: 1,
+                                                            line: "",
+                                                        },
+                                                    ),
                                                 },
                                             ),
                                             branches: [
                                                 IfTypeBranch {
                                                     type_: None(
                                                         None {
-                                                            position: Position {
-                                                                path: "",
-                                                                line_number: 1,
-                                                                column_number: 1,
-                                                                line: "",
-                                                            },
+                                                            position: Position(
+                                                                PositionInner {
+                                                                    path: "",
+                                                                    line_number: 1,
+                                                                    column_number: 1,
+                                                                    line: "",
+                                                                },
+                                                            ),
                                                         },
                                                     ),
                                                     expression: Boolean(
                                                         Boolean {
                                                             value: true,
-                                                            position: Position {
-                                                                path: "",
-                                                                line_number: 1,
-                                                                column_number: 1,
-                                                                line: "",
-                                                            },
+                                                            position: Position(
+                                                                PositionInner {
+                                                                    path: "",
+                                                                    line_number: 1,
+                                                                    column_number: 1,
+                                                                    line: "",
+                                                                },
+                                                            ),
                                                         },
                                                     ),
                                                 },
                                             ],
                                             else_: None,
-                                            position: Position {
-                                                path: "",
-                                                line_number: 1,
-                                                column_number: 1,
-                                                line: "",
-                                            },
+                                            position: Position(
+                                                PositionInner {
+                                                    path: "",
+                                                    line_number: 1,
+                                                    column_number: 1,
+                                                    line: "",
+                                                },
+                                            ),
                                         },
                                     ),
                                 },
                             ],
                             else_: None,
-                            position: Position {
-                                path: "",
-                                line_number: 1,
-                                column_number: 1,
-                                line: "",
-                            },
+                            position: Position(
+                                PositionInner {
+                                    path: "",
+                                    line_number: 1,
+                                    column_number: 1,
+                                    line: "",
+                                },
+                            ),
                         },
                     ),
-                    position: Position {
+                    position: Position(
+                        PositionInner {
+                            path: "",
+                            line_number: 1,
+                            column_number: 1,
+                            line: "",
+                        },
+                    ),
+                },
+                foreign_definition_configuration: None,
+                public: false,
+                position: Position(
+                    PositionInner {
                         path: "",
                         line_number: 1,
                         column_number: 1,
                         line: "",
                     },
-                },
-                foreign_definition_configuration: None,
-                public: false,
-                position: Position {
-                    path: "",
-                    line_number: 1,
-                    column_number: 1,
-                    line: "",
-                },
+                ),
             },
         ],
-        position: Position {
-            path: "",
-            line_number: 1,
-            column_number: 1,
-            line: "",
-        },
+        position: Position(
+            PositionInner {
+                path: "",
+                line_number: 1,
+                column_number: 1,
+                line: "",
+            },
+        ),
     },
 )

--- a/lib/hir-mir/src/transformation/hash_calculation/snapshots/hir_mir__transformation__hash_calculation__module__tests__transform_comparable_type.snap
+++ b/lib/hir-mir/src/transformation/hash_calculation/snapshots/hir_mir__transformation__hash_calculation__module__tests__transform_comparable_type.snap
@@ -10,43 +10,53 @@ Ok(
                 name: "a",
                 original_name: "",
                 type_: Map(
-                    Map {
-                        key: None(
-                            None {
-                                position: Position {
+                    Map(
+                        MapInner {
+                            key: None(
+                                None {
+                                    position: Position(
+                                        PositionInner {
+                                            path: "",
+                                            line_number: 1,
+                                            column_number: 1,
+                                            line: "",
+                                        },
+                                    ),
+                                },
+                            ),
+                            value: None(
+                                None {
+                                    position: Position(
+                                        PositionInner {
+                                            path: "",
+                                            line_number: 1,
+                                            column_number: 1,
+                                            line: "",
+                                        },
+                                    ),
+                                },
+                            ),
+                            position: Position(
+                                PositionInner {
                                     path: "",
                                     line_number: 1,
                                     column_number: 1,
                                     line: "",
                                 },
-                            },
-                        ),
-                        value: None(
-                            None {
-                                position: Position {
-                                    path: "",
-                                    line_number: 1,
-                                    column_number: 1,
-                                    line: "",
-                                },
-                            },
-                        ),
-                        position: Position {
-                            path: "",
-                            line_number: 1,
-                            column_number: 1,
-                            line: "",
+                            ),
                         },
-                    },
+                    ),
                 ),
                 public: false,
                 external: false,
-                position: Position {
-                    path: "",
-                    line_number: 1,
-                    column_number: 1,
-                    line: "",
-                },
+                position: Position(
+                    PositionInner {
+                        path: "",
+                        line_number: 1,
+                        column_number: 1,
+                        line: "",
+                    },
+                ),
             },
         ],
         foreign_declarations: [],
@@ -61,24 +71,28 @@ Ok(
                             name: "$x",
                             type_: Any(
                                 Any {
-                                    position: Position {
-                                        path: "",
-                                        line_number: 1,
-                                        column_number: 1,
-                                        line: "",
-                                    },
+                                    position: Position(
+                                        PositionInner {
+                                            path: "",
+                                            line_number: 1,
+                                            column_number: 1,
+                                            line: "",
+                                        },
+                                    ),
                                 },
                             ),
                         },
                     ],
                     result_type: Number(
                         Number {
-                            position: Position {
-                                path: "",
-                                line_number: 1,
-                                column_number: 1,
-                                line: "",
-                            },
+                            position: Position(
+                                PositionInner {
+                                    path: "",
+                                    line_number: 1,
+                                    column_number: 1,
+                                    line: "",
+                                },
+                            ),
                         },
                     ),
                     body: IfType(
@@ -87,70 +101,84 @@ Ok(
                             argument: Variable(
                                 Variable {
                                     name: "$x",
-                                    position: Position {
-                                        path: "",
-                                        line_number: 1,
-                                        column_number: 1,
-                                        line: "",
-                                    },
+                                    position: Position(
+                                        PositionInner {
+                                            path: "",
+                                            line_number: 1,
+                                            column_number: 1,
+                                            line: "",
+                                        },
+                                    ),
                                 },
                             ),
                             branches: [
                                 IfTypeBranch {
                                     type_: None(
                                         None {
-                                            position: Position {
-                                                path: "",
-                                                line_number: 1,
-                                                column_number: 1,
-                                                line: "",
-                                            },
+                                            position: Position(
+                                                PositionInner {
+                                                    path: "",
+                                                    line_number: 1,
+                                                    column_number: 1,
+                                                    line: "",
+                                                },
+                                            ),
                                         },
                                     ),
                                     expression: Number(
                                         Number {
                                             value: 0.0,
-                                            position: Position {
-                                                path: "",
-                                                line_number: 1,
-                                                column_number: 1,
-                                                line: "",
-                                            },
+                                            position: Position(
+                                                PositionInner {
+                                                    path: "",
+                                                    line_number: 1,
+                                                    column_number: 1,
+                                                    line: "",
+                                                },
+                                            ),
                                         },
                                     ),
                                 },
                             ],
                             else_: None,
-                            position: Position {
-                                path: "",
-                                line_number: 1,
-                                column_number: 1,
-                                line: "",
-                            },
+                            position: Position(
+                                PositionInner {
+                                    path: "",
+                                    line_number: 1,
+                                    column_number: 1,
+                                    line: "",
+                                },
+                            ),
                         },
                     ),
-                    position: Position {
+                    position: Position(
+                        PositionInner {
+                            path: "",
+                            line_number: 1,
+                            column_number: 1,
+                            line: "",
+                        },
+                    ),
+                },
+                foreign_definition_configuration: None,
+                public: false,
+                position: Position(
+                    PositionInner {
                         path: "",
                         line_number: 1,
                         column_number: 1,
                         line: "",
                     },
-                },
-                foreign_definition_configuration: None,
-                public: false,
-                position: Position {
-                    path: "",
-                    line_number: 1,
-                    column_number: 1,
-                    line: "",
-                },
+                ),
             },
         ],
-        position: Position {
-            path: "",
-            line_number: 1,
-            column_number: 1,
-            line: "",
-        },
+        position: Position(
+            PositionInner {
+                path: "",
+                line_number: 1,
+                column_number: 1,
+                line: "",
+            },
+        ),
     },
 )

--- a/lib/hir-mir/src/transformation/map_context/snapshots/hir_mir__transformation__map_context__module__tests__transform_function_value.snap
+++ b/lib/hir-mir/src/transformation/map_context/snapshots/hir_mir__transformation__map_context__module__tests__transform_function_value.snap
@@ -15,73 +15,91 @@ Ok(
                 lambda: Lambda {
                     arguments: [],
                     result_type: Reference(
-                        Reference {
-                            name: "mapContext",
-                            position: Position {
-                                path: "",
-                                line_number: 1,
-                                column_number: 1,
-                                line: "",
+                        Reference(
+                            ReferenceInner {
+                                name: "mapContext",
+                                position: Position(
+                                    PositionInner {
+                                        path: "",
+                                        line_number: 1,
+                                        column_number: 1,
+                                        line: "",
+                                    },
+                                ),
                             },
-                        },
+                        ),
                     ),
                     body: Map(
                         Map {
                             key_type: None(
                                 None {
-                                    position: Position {
-                                        path: "",
-                                        line_number: 1,
-                                        column_number: 1,
-                                        line: "",
-                                    },
+                                    position: Position(
+                                        PositionInner {
+                                            path: "",
+                                            line_number: 1,
+                                            column_number: 1,
+                                            line: "",
+                                        },
+                                    ),
                                 },
                             ),
                             value_type: Function(
-                                Function {
-                                    arguments: [],
-                                    result: None(
-                                        None {
-                                            position: Position {
+                                Function(
+                                    FunctionInner {
+                                        arguments: [],
+                                        result: None(
+                                            None {
+                                                position: Position(
+                                                    PositionInner {
+                                                        path: "",
+                                                        line_number: 1,
+                                                        column_number: 1,
+                                                        line: "",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                        position: Position(
+                                            PositionInner {
                                                 path: "",
                                                 line_number: 1,
                                                 column_number: 1,
                                                 line: "",
                                             },
-                                        },
-                                    ),
-                                    position: Position {
-                                        path: "",
-                                        line_number: 1,
-                                        column_number: 1,
-                                        line: "",
+                                        ),
                                     },
-                                },
+                                ),
                             ),
                             elements: [],
-                            position: Position {
-                                path: "",
-                                line_number: 1,
-                                column_number: 1,
-                                line: "",
-                            },
+                            position: Position(
+                                PositionInner {
+                                    path: "",
+                                    line_number: 1,
+                                    column_number: 1,
+                                    line: "",
+                                },
+                            ),
                         },
                     ),
-                    position: Position {
+                    position: Position(
+                        PositionInner {
+                            path: "",
+                            line_number: 1,
+                            column_number: 1,
+                            line: "",
+                        },
+                    ),
+                },
+                foreign_definition_configuration: None,
+                public: false,
+                position: Position(
+                    PositionInner {
                         path: "",
                         line_number: 1,
                         column_number: 1,
                         line: "",
                     },
-                },
-                foreign_definition_configuration: None,
-                public: false,
-                position: Position {
-                    path: "",
-                    line_number: 1,
-                    column_number: 1,
-                    line: "",
-                },
+                ),
             },
             FunctionDefinition {
                 name: "hir:map:context:8bbb62926defb736",
@@ -89,223 +107,277 @@ Ok(
                 lambda: Lambda {
                     arguments: [],
                     result_type: Reference(
-                        Reference {
-                            name: "mapContext",
-                            position: Position {
-                                path: "",
-                                line_number: 1,
-                                column_number: 1,
-                                line: "",
-                            },
-                        },
-                    ),
-                    body: Call(
-                        Call {
-                            function_type: Some(
-                                Function(
-                                    Function {
-                                        arguments: [
-                                            Function(
-                                                Function {
-                                                    arguments: [
-                                                        Any(
-                                                            Any {
-                                                                position: Position {
-                                                                    path: "",
-                                                                    line_number: 1,
-                                                                    column_number: 1,
-                                                                    line: "",
-                                                                },
-                                                            },
-                                                        ),
-                                                        Any(
-                                                            Any {
-                                                                position: Position {
-                                                                    path: "",
-                                                                    line_number: 1,
-                                                                    column_number: 1,
-                                                                    line: "",
-                                                                },
-                                                            },
-                                                        ),
-                                                    ],
-                                                    result: Boolean(
-                                                        Boolean {
-                                                            position: Position {
-                                                                path: "",
-                                                                line_number: 1,
-                                                                column_number: 1,
-                                                                line: "",
-                                                            },
-                                                        },
-                                                    ),
-                                                    position: Position {
-                                                        path: "",
-                                                        line_number: 1,
-                                                        column_number: 1,
-                                                        line: "",
-                                                    },
-                                                },
-                                            ),
-                                            Function(
-                                                Function {
-                                                    arguments: [
-                                                        Any(
-                                                            Any {
-                                                                position: Position {
-                                                                    path: "",
-                                                                    line_number: 1,
-                                                                    column_number: 1,
-                                                                    line: "",
-                                                                },
-                                                            },
-                                                        ),
-                                                    ],
-                                                    result: Number(
-                                                        Number {
-                                                            position: Position {
-                                                                path: "",
-                                                                line_number: 1,
-                                                                column_number: 1,
-                                                                line: "",
-                                                            },
-                                                        },
-                                                    ),
-                                                    position: Position {
-                                                        path: "",
-                                                        line_number: 1,
-                                                        column_number: 1,
-                                                        line: "",
-                                                    },
-                                                },
-                                            ),
-                                            Function(
-                                                Function {
-                                                    arguments: [
-                                                        Any(
-                                                            Any {
-                                                                position: Position {
-                                                                    path: "",
-                                                                    line_number: 1,
-                                                                    column_number: 1,
-                                                                    line: "",
-                                                                },
-                                                            },
-                                                        ),
-                                                        Any(
-                                                            Any {
-                                                                position: Position {
-                                                                    path: "",
-                                                                    line_number: 1,
-                                                                    column_number: 1,
-                                                                    line: "",
-                                                                },
-                                                            },
-                                                        ),
-                                                    ],
-                                                    result: Boolean(
-                                                        Boolean {
-                                                            position: Position {
-                                                                path: "",
-                                                                line_number: 1,
-                                                                column_number: 1,
-                                                                line: "",
-                                                            },
-                                                        },
-                                                    ),
-                                                    position: Position {
-                                                        path: "",
-                                                        line_number: 1,
-                                                        column_number: 1,
-                                                        line: "",
-                                                    },
-                                                },
-                                            ),
-                                            Function(
-                                                Function {
-                                                    arguments: [
-                                                        Any(
-                                                            Any {
-                                                                position: Position {
-                                                                    path: "",
-                                                                    line_number: 1,
-                                                                    column_number: 1,
-                                                                    line: "",
-                                                                },
-                                                            },
-                                                        ),
-                                                    ],
-                                                    result: Number(
-                                                        Number {
-                                                            position: Position {
-                                                                path: "",
-                                                                line_number: 1,
-                                                                column_number: 1,
-                                                                line: "",
-                                                            },
-                                                        },
-                                                    ),
-                                                    position: Position {
-                                                        path: "",
-                                                        line_number: 1,
-                                                        column_number: 1,
-                                                        line: "",
-                                                    },
-                                                },
-                                            ),
-                                        ],
-                                        result: Reference(
-                                            Reference {
-                                                name: "mapContext",
-                                                position: Position {
-                                                    path: "",
-                                                    line_number: 1,
-                                                    column_number: 1,
-                                                    line: "",
-                                                },
-                                            },
-                                        ),
-                                        position: Position {
-                                            path: "",
-                                            line_number: 1,
-                                            column_number: 1,
-                                            line: "",
-                                        },
-                                    },
-                                ),
-                            ),
-                            function: Variable(
-                                Variable {
-                                    name: "newMapContext",
-                                    position: Position {
+                        Reference(
+                            ReferenceInner {
+                                name: "mapContext",
+                                position: Position(
+                                    PositionInner {
                                         path: "",
                                         line_number: 1,
                                         column_number: 1,
                                         line: "",
                                     },
+                                ),
+                            },
+                        ),
+                    ),
+                    body: Call(
+                        Call {
+                            function_type: Some(
+                                Function(
+                                    Function(
+                                        FunctionInner {
+                                            arguments: [
+                                                Function(
+                                                    Function(
+                                                        FunctionInner {
+                                                            arguments: [
+                                                                Any(
+                                                                    Any {
+                                                                        position: Position(
+                                                                            PositionInner {
+                                                                                path: "",
+                                                                                line_number: 1,
+                                                                                column_number: 1,
+                                                                                line: "",
+                                                                            },
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                                Any(
+                                                                    Any {
+                                                                        position: Position(
+                                                                            PositionInner {
+                                                                                path: "",
+                                                                                line_number: 1,
+                                                                                column_number: 1,
+                                                                                line: "",
+                                                                            },
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                            ],
+                                                            result: Boolean(
+                                                                Boolean {
+                                                                    position: Position(
+                                                                        PositionInner {
+                                                                            path: "",
+                                                                            line_number: 1,
+                                                                            column_number: 1,
+                                                                            line: "",
+                                                                        },
+                                                                    ),
+                                                                },
+                                                            ),
+                                                            position: Position(
+                                                                PositionInner {
+                                                                    path: "",
+                                                                    line_number: 1,
+                                                                    column_number: 1,
+                                                                    line: "",
+                                                                },
+                                                            ),
+                                                        },
+                                                    ),
+                                                ),
+                                                Function(
+                                                    Function(
+                                                        FunctionInner {
+                                                            arguments: [
+                                                                Any(
+                                                                    Any {
+                                                                        position: Position(
+                                                                            PositionInner {
+                                                                                path: "",
+                                                                                line_number: 1,
+                                                                                column_number: 1,
+                                                                                line: "",
+                                                                            },
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                            ],
+                                                            result: Number(
+                                                                Number {
+                                                                    position: Position(
+                                                                        PositionInner {
+                                                                            path: "",
+                                                                            line_number: 1,
+                                                                            column_number: 1,
+                                                                            line: "",
+                                                                        },
+                                                                    ),
+                                                                },
+                                                            ),
+                                                            position: Position(
+                                                                PositionInner {
+                                                                    path: "",
+                                                                    line_number: 1,
+                                                                    column_number: 1,
+                                                                    line: "",
+                                                                },
+                                                            ),
+                                                        },
+                                                    ),
+                                                ),
+                                                Function(
+                                                    Function(
+                                                        FunctionInner {
+                                                            arguments: [
+                                                                Any(
+                                                                    Any {
+                                                                        position: Position(
+                                                                            PositionInner {
+                                                                                path: "",
+                                                                                line_number: 1,
+                                                                                column_number: 1,
+                                                                                line: "",
+                                                                            },
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                                Any(
+                                                                    Any {
+                                                                        position: Position(
+                                                                            PositionInner {
+                                                                                path: "",
+                                                                                line_number: 1,
+                                                                                column_number: 1,
+                                                                                line: "",
+                                                                            },
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                            ],
+                                                            result: Boolean(
+                                                                Boolean {
+                                                                    position: Position(
+                                                                        PositionInner {
+                                                                            path: "",
+                                                                            line_number: 1,
+                                                                            column_number: 1,
+                                                                            line: "",
+                                                                        },
+                                                                    ),
+                                                                },
+                                                            ),
+                                                            position: Position(
+                                                                PositionInner {
+                                                                    path: "",
+                                                                    line_number: 1,
+                                                                    column_number: 1,
+                                                                    line: "",
+                                                                },
+                                                            ),
+                                                        },
+                                                    ),
+                                                ),
+                                                Function(
+                                                    Function(
+                                                        FunctionInner {
+                                                            arguments: [
+                                                                Any(
+                                                                    Any {
+                                                                        position: Position(
+                                                                            PositionInner {
+                                                                                path: "",
+                                                                                line_number: 1,
+                                                                                column_number: 1,
+                                                                                line: "",
+                                                                            },
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                            ],
+                                                            result: Number(
+                                                                Number {
+                                                                    position: Position(
+                                                                        PositionInner {
+                                                                            path: "",
+                                                                            line_number: 1,
+                                                                            column_number: 1,
+                                                                            line: "",
+                                                                        },
+                                                                    ),
+                                                                },
+                                                            ),
+                                                            position: Position(
+                                                                PositionInner {
+                                                                    path: "",
+                                                                    line_number: 1,
+                                                                    column_number: 1,
+                                                                    line: "",
+                                                                },
+                                                            ),
+                                                        },
+                                                    ),
+                                                ),
+                                            ],
+                                            result: Reference(
+                                                Reference(
+                                                    ReferenceInner {
+                                                        name: "mapContext",
+                                                        position: Position(
+                                                            PositionInner {
+                                                                path: "",
+                                                                line_number: 1,
+                                                                column_number: 1,
+                                                                line: "",
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                            ),
+                                            position: Position(
+                                                PositionInner {
+                                                    path: "",
+                                                    line_number: 1,
+                                                    column_number: 1,
+                                                    line: "",
+                                                },
+                                            ),
+                                        },
+                                    ),
+                                ),
+                            ),
+                            function: Variable(
+                                Variable {
+                                    name: "newMapContext",
+                                    position: Position(
+                                        PositionInner {
+                                            path: "",
+                                            line_number: 1,
+                                            column_number: 1,
+                                            line: "",
+                                        },
+                                    ),
                                 },
                             ),
                             arguments: [
                                 Variable(
                                     Variable {
                                         name: "hir:equal:d409c28886113c9b",
-                                        position: Position {
-                                            path: "",
-                                            line_number: 1,
-                                            column_number: 1,
-                                            line: "",
-                                        },
+                                        position: Position(
+                                            PositionInner {
+                                                path: "",
+                                                line_number: 1,
+                                                column_number: 1,
+                                                line: "",
+                                            },
+                                        ),
                                     },
                                 ),
                                 Variable(
                                     Variable {
                                         name: "hir:hash:d409c28886113c9b",
-                                        position: Position {
-                                            path: "",
-                                            line_number: 1,
-                                            column_number: 1,
-                                            line: "",
-                                        },
+                                        position: Position(
+                                            PositionInner {
+                                                path: "",
+                                                line_number: 1,
+                                                column_number: 1,
+                                                line: "",
+                                            },
+                                        ),
                                     },
                                 ),
                                 Lambda(
@@ -315,12 +387,14 @@ Ok(
                                                 name: "",
                                                 type_: Any(
                                                     Any {
-                                                        position: Position {
-                                                            path: "",
-                                                            line_number: 1,
-                                                            column_number: 1,
-                                                            line: "",
-                                                        },
+                                                        position: Position(
+                                                            PositionInner {
+                                                                path: "",
+                                                                line_number: 1,
+                                                                column_number: 1,
+                                                                line: "",
+                                                            },
+                                                        ),
                                                     },
                                                 ),
                                             },
@@ -328,43 +402,51 @@ Ok(
                                                 name: "",
                                                 type_: Any(
                                                     Any {
-                                                        position: Position {
-                                                            path: "",
-                                                            line_number: 1,
-                                                            column_number: 1,
-                                                            line: "",
-                                                        },
+                                                        position: Position(
+                                                            PositionInner {
+                                                                path: "",
+                                                                line_number: 1,
+                                                                column_number: 1,
+                                                                line: "",
+                                                            },
+                                                        ),
                                                     },
                                                 ),
                                             },
                                         ],
                                         result_type: Boolean(
                                             Boolean {
-                                                position: Position {
-                                                    path: "",
-                                                    line_number: 1,
-                                                    column_number: 1,
-                                                    line: "",
-                                                },
+                                                position: Position(
+                                                    PositionInner {
+                                                        path: "",
+                                                        line_number: 1,
+                                                        column_number: 1,
+                                                        line: "",
+                                                    },
+                                                ),
                                             },
                                         ),
                                         body: Boolean(
                                             Boolean {
                                                 value: false,
-                                                position: Position {
-                                                    path: "",
-                                                    line_number: 1,
-                                                    column_number: 1,
-                                                    line: "",
-                                                },
+                                                position: Position(
+                                                    PositionInner {
+                                                        path: "",
+                                                        line_number: 1,
+                                                        column_number: 1,
+                                                        line: "",
+                                                    },
+                                                ),
                                             },
                                         ),
-                                        position: Position {
-                                            path: "",
-                                            line_number: 1,
-                                            column_number: 1,
-                                            line: "",
-                                        },
+                                        position: Position(
+                                            PositionInner {
+                                                path: "",
+                                                line_number: 1,
+                                                column_number: 1,
+                                                line: "",
+                                            },
+                                        ),
                                     },
                                 ),
                                 Lambda(
@@ -374,76 +456,92 @@ Ok(
                                                 name: "",
                                                 type_: Any(
                                                     Any {
-                                                        position: Position {
-                                                            path: "",
-                                                            line_number: 1,
-                                                            column_number: 1,
-                                                            line: "",
-                                                        },
+                                                        position: Position(
+                                                            PositionInner {
+                                                                path: "",
+                                                                line_number: 1,
+                                                                column_number: 1,
+                                                                line: "",
+                                                            },
+                                                        ),
                                                     },
                                                 ),
                                             },
                                         ],
                                         result_type: Number(
                                             Number {
-                                                position: Position {
-                                                    path: "",
-                                                    line_number: 1,
-                                                    column_number: 1,
-                                                    line: "",
-                                                },
+                                                position: Position(
+                                                    PositionInner {
+                                                        path: "",
+                                                        line_number: 1,
+                                                        column_number: 1,
+                                                        line: "",
+                                                    },
+                                                ),
                                             },
                                         ),
                                         body: Number(
                                             Number {
                                                 value: 0.0,
-                                                position: Position {
-                                                    path: "",
-                                                    line_number: 1,
-                                                    column_number: 1,
-                                                    line: "",
-                                                },
+                                                position: Position(
+                                                    PositionInner {
+                                                        path: "",
+                                                        line_number: 1,
+                                                        column_number: 1,
+                                                        line: "",
+                                                    },
+                                                ),
                                             },
                                         ),
-                                        position: Position {
-                                            path: "",
-                                            line_number: 1,
-                                            column_number: 1,
-                                            line: "",
-                                        },
+                                        position: Position(
+                                            PositionInner {
+                                                path: "",
+                                                line_number: 1,
+                                                column_number: 1,
+                                                line: "",
+                                            },
+                                        ),
                                     },
                                 ),
                             ],
-                            position: Position {
-                                path: "",
-                                line_number: 1,
-                                column_number: 1,
-                                line: "",
-                            },
+                            position: Position(
+                                PositionInner {
+                                    path: "",
+                                    line_number: 1,
+                                    column_number: 1,
+                                    line: "",
+                                },
+                            ),
                         },
                     ),
-                    position: Position {
+                    position: Position(
+                        PositionInner {
+                            path: "",
+                            line_number: 1,
+                            column_number: 1,
+                            line: "",
+                        },
+                    ),
+                },
+                foreign_definition_configuration: None,
+                public: false,
+                position: Position(
+                    PositionInner {
                         path: "",
                         line_number: 1,
                         column_number: 1,
                         line: "",
                     },
-                },
-                foreign_definition_configuration: None,
-                public: false,
-                position: Position {
-                    path: "",
-                    line_number: 1,
-                    column_number: 1,
-                    line: "",
-                },
+                ),
             },
         ],
-        position: Position {
-            path: "",
-            line_number: 1,
-            column_number: 1,
-            line: "",
-        },
+        position: Position(
+            PositionInner {
+                path: "",
+                line_number: 1,
+                column_number: 1,
+                line: "",
+            },
+        ),
     },
 )

--- a/lib/hir-mir/src/transformation/map_context/snapshots/hir_mir__transformation__map_context__module__tests__transform_none_key_and_none_value.snap
+++ b/lib/hir-mir/src/transformation/map_context/snapshots/hir_mir__transformation__map_context__module__tests__transform_none_key_and_none_value.snap
@@ -15,62 +15,76 @@ Ok(
                 lambda: Lambda {
                     arguments: [],
                     result_type: Reference(
-                        Reference {
-                            name: "mapContext",
-                            position: Position {
-                                path: "",
-                                line_number: 1,
-                                column_number: 1,
-                                line: "",
+                        Reference(
+                            ReferenceInner {
+                                name: "mapContext",
+                                position: Position(
+                                    PositionInner {
+                                        path: "",
+                                        line_number: 1,
+                                        column_number: 1,
+                                        line: "",
+                                    },
+                                ),
                             },
-                        },
+                        ),
                     ),
                     body: Map(
                         Map {
                             key_type: None(
                                 None {
-                                    position: Position {
-                                        path: "",
-                                        line_number: 1,
-                                        column_number: 1,
-                                        line: "",
-                                    },
+                                    position: Position(
+                                        PositionInner {
+                                            path: "",
+                                            line_number: 1,
+                                            column_number: 1,
+                                            line: "",
+                                        },
+                                    ),
                                 },
                             ),
                             value_type: None(
                                 None {
-                                    position: Position {
-                                        path: "",
-                                        line_number: 1,
-                                        column_number: 1,
-                                        line: "",
-                                    },
+                                    position: Position(
+                                        PositionInner {
+                                            path: "",
+                                            line_number: 1,
+                                            column_number: 1,
+                                            line: "",
+                                        },
+                                    ),
                                 },
                             ),
                             elements: [],
-                            position: Position {
-                                path: "",
-                                line_number: 1,
-                                column_number: 1,
-                                line: "",
-                            },
+                            position: Position(
+                                PositionInner {
+                                    path: "",
+                                    line_number: 1,
+                                    column_number: 1,
+                                    line: "",
+                                },
+                            ),
                         },
                     ),
-                    position: Position {
+                    position: Position(
+                        PositionInner {
+                            path: "",
+                            line_number: 1,
+                            column_number: 1,
+                            line: "",
+                        },
+                    ),
+                },
+                foreign_definition_configuration: None,
+                public: false,
+                position: Position(
+                    PositionInner {
                         path: "",
                         line_number: 1,
                         column_number: 1,
                         line: "",
                     },
-                },
-                foreign_definition_configuration: None,
-                public: false,
-                position: Position {
-                    path: "",
-                    line_number: 1,
-                    column_number: 1,
-                    line: "",
-                },
+                ),
             },
             FunctionDefinition {
                 name: "hir:map:context:829f738c8f9ee2f4",
@@ -78,278 +92,344 @@ Ok(
                 lambda: Lambda {
                     arguments: [],
                     result_type: Reference(
-                        Reference {
-                            name: "mapContext",
-                            position: Position {
-                                path: "",
-                                line_number: 1,
-                                column_number: 1,
-                                line: "",
-                            },
-                        },
-                    ),
-                    body: Call(
-                        Call {
-                            function_type: Some(
-                                Function(
-                                    Function {
-                                        arguments: [
-                                            Function(
-                                                Function {
-                                                    arguments: [
-                                                        Any(
-                                                            Any {
-                                                                position: Position {
-                                                                    path: "",
-                                                                    line_number: 1,
-                                                                    column_number: 1,
-                                                                    line: "",
-                                                                },
-                                                            },
-                                                        ),
-                                                        Any(
-                                                            Any {
-                                                                position: Position {
-                                                                    path: "",
-                                                                    line_number: 1,
-                                                                    column_number: 1,
-                                                                    line: "",
-                                                                },
-                                                            },
-                                                        ),
-                                                    ],
-                                                    result: Boolean(
-                                                        Boolean {
-                                                            position: Position {
-                                                                path: "",
-                                                                line_number: 1,
-                                                                column_number: 1,
-                                                                line: "",
-                                                            },
-                                                        },
-                                                    ),
-                                                    position: Position {
-                                                        path: "",
-                                                        line_number: 1,
-                                                        column_number: 1,
-                                                        line: "",
-                                                    },
-                                                },
-                                            ),
-                                            Function(
-                                                Function {
-                                                    arguments: [
-                                                        Any(
-                                                            Any {
-                                                                position: Position {
-                                                                    path: "",
-                                                                    line_number: 1,
-                                                                    column_number: 1,
-                                                                    line: "",
-                                                                },
-                                                            },
-                                                        ),
-                                                    ],
-                                                    result: Number(
-                                                        Number {
-                                                            position: Position {
-                                                                path: "",
-                                                                line_number: 1,
-                                                                column_number: 1,
-                                                                line: "",
-                                                            },
-                                                        },
-                                                    ),
-                                                    position: Position {
-                                                        path: "",
-                                                        line_number: 1,
-                                                        column_number: 1,
-                                                        line: "",
-                                                    },
-                                                },
-                                            ),
-                                            Function(
-                                                Function {
-                                                    arguments: [
-                                                        Any(
-                                                            Any {
-                                                                position: Position {
-                                                                    path: "",
-                                                                    line_number: 1,
-                                                                    column_number: 1,
-                                                                    line: "",
-                                                                },
-                                                            },
-                                                        ),
-                                                        Any(
-                                                            Any {
-                                                                position: Position {
-                                                                    path: "",
-                                                                    line_number: 1,
-                                                                    column_number: 1,
-                                                                    line: "",
-                                                                },
-                                                            },
-                                                        ),
-                                                    ],
-                                                    result: Boolean(
-                                                        Boolean {
-                                                            position: Position {
-                                                                path: "",
-                                                                line_number: 1,
-                                                                column_number: 1,
-                                                                line: "",
-                                                            },
-                                                        },
-                                                    ),
-                                                    position: Position {
-                                                        path: "",
-                                                        line_number: 1,
-                                                        column_number: 1,
-                                                        line: "",
-                                                    },
-                                                },
-                                            ),
-                                            Function(
-                                                Function {
-                                                    arguments: [
-                                                        Any(
-                                                            Any {
-                                                                position: Position {
-                                                                    path: "",
-                                                                    line_number: 1,
-                                                                    column_number: 1,
-                                                                    line: "",
-                                                                },
-                                                            },
-                                                        ),
-                                                    ],
-                                                    result: Number(
-                                                        Number {
-                                                            position: Position {
-                                                                path: "",
-                                                                line_number: 1,
-                                                                column_number: 1,
-                                                                line: "",
-                                                            },
-                                                        },
-                                                    ),
-                                                    position: Position {
-                                                        path: "",
-                                                        line_number: 1,
-                                                        column_number: 1,
-                                                        line: "",
-                                                    },
-                                                },
-                                            ),
-                                        ],
-                                        result: Reference(
-                                            Reference {
-                                                name: "mapContext",
-                                                position: Position {
-                                                    path: "",
-                                                    line_number: 1,
-                                                    column_number: 1,
-                                                    line: "",
-                                                },
-                                            },
-                                        ),
-                                        position: Position {
-                                            path: "",
-                                            line_number: 1,
-                                            column_number: 1,
-                                            line: "",
-                                        },
-                                    },
-                                ),
-                            ),
-                            function: Variable(
-                                Variable {
-                                    name: "newMapContext",
-                                    position: Position {
+                        Reference(
+                            ReferenceInner {
+                                name: "mapContext",
+                                position: Position(
+                                    PositionInner {
                                         path: "",
                                         line_number: 1,
                                         column_number: 1,
                                         line: "",
                                     },
+                                ),
+                            },
+                        ),
+                    ),
+                    body: Call(
+                        Call {
+                            function_type: Some(
+                                Function(
+                                    Function(
+                                        FunctionInner {
+                                            arguments: [
+                                                Function(
+                                                    Function(
+                                                        FunctionInner {
+                                                            arguments: [
+                                                                Any(
+                                                                    Any {
+                                                                        position: Position(
+                                                                            PositionInner {
+                                                                                path: "",
+                                                                                line_number: 1,
+                                                                                column_number: 1,
+                                                                                line: "",
+                                                                            },
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                                Any(
+                                                                    Any {
+                                                                        position: Position(
+                                                                            PositionInner {
+                                                                                path: "",
+                                                                                line_number: 1,
+                                                                                column_number: 1,
+                                                                                line: "",
+                                                                            },
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                            ],
+                                                            result: Boolean(
+                                                                Boolean {
+                                                                    position: Position(
+                                                                        PositionInner {
+                                                                            path: "",
+                                                                            line_number: 1,
+                                                                            column_number: 1,
+                                                                            line: "",
+                                                                        },
+                                                                    ),
+                                                                },
+                                                            ),
+                                                            position: Position(
+                                                                PositionInner {
+                                                                    path: "",
+                                                                    line_number: 1,
+                                                                    column_number: 1,
+                                                                    line: "",
+                                                                },
+                                                            ),
+                                                        },
+                                                    ),
+                                                ),
+                                                Function(
+                                                    Function(
+                                                        FunctionInner {
+                                                            arguments: [
+                                                                Any(
+                                                                    Any {
+                                                                        position: Position(
+                                                                            PositionInner {
+                                                                                path: "",
+                                                                                line_number: 1,
+                                                                                column_number: 1,
+                                                                                line: "",
+                                                                            },
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                            ],
+                                                            result: Number(
+                                                                Number {
+                                                                    position: Position(
+                                                                        PositionInner {
+                                                                            path: "",
+                                                                            line_number: 1,
+                                                                            column_number: 1,
+                                                                            line: "",
+                                                                        },
+                                                                    ),
+                                                                },
+                                                            ),
+                                                            position: Position(
+                                                                PositionInner {
+                                                                    path: "",
+                                                                    line_number: 1,
+                                                                    column_number: 1,
+                                                                    line: "",
+                                                                },
+                                                            ),
+                                                        },
+                                                    ),
+                                                ),
+                                                Function(
+                                                    Function(
+                                                        FunctionInner {
+                                                            arguments: [
+                                                                Any(
+                                                                    Any {
+                                                                        position: Position(
+                                                                            PositionInner {
+                                                                                path: "",
+                                                                                line_number: 1,
+                                                                                column_number: 1,
+                                                                                line: "",
+                                                                            },
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                                Any(
+                                                                    Any {
+                                                                        position: Position(
+                                                                            PositionInner {
+                                                                                path: "",
+                                                                                line_number: 1,
+                                                                                column_number: 1,
+                                                                                line: "",
+                                                                            },
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                            ],
+                                                            result: Boolean(
+                                                                Boolean {
+                                                                    position: Position(
+                                                                        PositionInner {
+                                                                            path: "",
+                                                                            line_number: 1,
+                                                                            column_number: 1,
+                                                                            line: "",
+                                                                        },
+                                                                    ),
+                                                                },
+                                                            ),
+                                                            position: Position(
+                                                                PositionInner {
+                                                                    path: "",
+                                                                    line_number: 1,
+                                                                    column_number: 1,
+                                                                    line: "",
+                                                                },
+                                                            ),
+                                                        },
+                                                    ),
+                                                ),
+                                                Function(
+                                                    Function(
+                                                        FunctionInner {
+                                                            arguments: [
+                                                                Any(
+                                                                    Any {
+                                                                        position: Position(
+                                                                            PositionInner {
+                                                                                path: "",
+                                                                                line_number: 1,
+                                                                                column_number: 1,
+                                                                                line: "",
+                                                                            },
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                            ],
+                                                            result: Number(
+                                                                Number {
+                                                                    position: Position(
+                                                                        PositionInner {
+                                                                            path: "",
+                                                                            line_number: 1,
+                                                                            column_number: 1,
+                                                                            line: "",
+                                                                        },
+                                                                    ),
+                                                                },
+                                                            ),
+                                                            position: Position(
+                                                                PositionInner {
+                                                                    path: "",
+                                                                    line_number: 1,
+                                                                    column_number: 1,
+                                                                    line: "",
+                                                                },
+                                                            ),
+                                                        },
+                                                    ),
+                                                ),
+                                            ],
+                                            result: Reference(
+                                                Reference(
+                                                    ReferenceInner {
+                                                        name: "mapContext",
+                                                        position: Position(
+                                                            PositionInner {
+                                                                path: "",
+                                                                line_number: 1,
+                                                                column_number: 1,
+                                                                line: "",
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                            ),
+                                            position: Position(
+                                                PositionInner {
+                                                    path: "",
+                                                    line_number: 1,
+                                                    column_number: 1,
+                                                    line: "",
+                                                },
+                                            ),
+                                        },
+                                    ),
+                                ),
+                            ),
+                            function: Variable(
+                                Variable {
+                                    name: "newMapContext",
+                                    position: Position(
+                                        PositionInner {
+                                            path: "",
+                                            line_number: 1,
+                                            column_number: 1,
+                                            line: "",
+                                        },
+                                    ),
                                 },
                             ),
                             arguments: [
                                 Variable(
                                     Variable {
                                         name: "hir:equal:d409c28886113c9b",
-                                        position: Position {
-                                            path: "",
-                                            line_number: 1,
-                                            column_number: 1,
-                                            line: "",
-                                        },
+                                        position: Position(
+                                            PositionInner {
+                                                path: "",
+                                                line_number: 1,
+                                                column_number: 1,
+                                                line: "",
+                                            },
+                                        ),
                                     },
                                 ),
                                 Variable(
                                     Variable {
                                         name: "hir:hash:d409c28886113c9b",
-                                        position: Position {
-                                            path: "",
-                                            line_number: 1,
-                                            column_number: 1,
-                                            line: "",
-                                        },
+                                        position: Position(
+                                            PositionInner {
+                                                path: "",
+                                                line_number: 1,
+                                                column_number: 1,
+                                                line: "",
+                                            },
+                                        ),
                                     },
                                 ),
                                 Variable(
                                     Variable {
                                         name: "hir:equal:d409c28886113c9b",
-                                        position: Position {
-                                            path: "",
-                                            line_number: 1,
-                                            column_number: 1,
-                                            line: "",
-                                        },
+                                        position: Position(
+                                            PositionInner {
+                                                path: "",
+                                                line_number: 1,
+                                                column_number: 1,
+                                                line: "",
+                                            },
+                                        ),
                                     },
                                 ),
                                 Variable(
                                     Variable {
                                         name: "hir:hash:d409c28886113c9b",
-                                        position: Position {
-                                            path: "",
-                                            line_number: 1,
-                                            column_number: 1,
-                                            line: "",
-                                        },
+                                        position: Position(
+                                            PositionInner {
+                                                path: "",
+                                                line_number: 1,
+                                                column_number: 1,
+                                                line: "",
+                                            },
+                                        ),
                                     },
                                 ),
                             ],
-                            position: Position {
-                                path: "",
-                                line_number: 1,
-                                column_number: 1,
-                                line: "",
-                            },
+                            position: Position(
+                                PositionInner {
+                                    path: "",
+                                    line_number: 1,
+                                    column_number: 1,
+                                    line: "",
+                                },
+                            ),
                         },
                     ),
-                    position: Position {
+                    position: Position(
+                        PositionInner {
+                            path: "",
+                            line_number: 1,
+                            column_number: 1,
+                            line: "",
+                        },
+                    ),
+                },
+                foreign_definition_configuration: None,
+                public: false,
+                position: Position(
+                    PositionInner {
                         path: "",
                         line_number: 1,
                         column_number: 1,
                         line: "",
                     },
-                },
-                foreign_definition_configuration: None,
-                public: false,
-                position: Position {
-                    path: "",
-                    line_number: 1,
-                    column_number: 1,
-                    line: "",
-                },
+                ),
             },
         ],
-        position: Position {
-            path: "",
-            line_number: 1,
-            column_number: 1,
-            line: "",
-        },
+        position: Position(
+            PositionInner {
+                path: "",
+                line_number: 1,
+                column_number: 1,
+                line: "",
+            },
+        ),
     },
 )

--- a/lib/hir-mir/src/transformation/snapshots/hir_mir__transformation__if_list__tests__transform_if_list_with_any_type.snap
+++ b/lib/hir-mir/src/transformation/snapshots/hir_mir__transformation__if_list__tests__transform_if_list_with_any_type.snap
@@ -10,104 +10,132 @@ Ok(
                 Call {
                     function_type: Some(
                         Function(
-                            Function {
-                                arguments: [
-                                    Reference(
-                                        Reference {
-                                            name: "anyList",
-                                            position: Position {
-                                                path: "",
-                                                line_number: 1,
-                                                column_number: 1,
-                                                line: "",
+                            Function(
+                                FunctionInner {
+                                    arguments: [
+                                        Reference(
+                                            Reference(
+                                                ReferenceInner {
+                                                    name: "anyList",
+                                                    position: Position(
+                                                        PositionInner {
+                                                            path: "",
+                                                            line_number: 1,
+                                                            column_number: 1,
+                                                            line: "",
+                                                        },
+                                                    ),
+                                                },
+                                            ),
+                                        ),
+                                    ],
+                                    result: Union(
+                                        Union(
+                                            UnionInner {
+                                                lhs: Reference(
+                                                    Reference(
+                                                        ReferenceInner {
+                                                            name: "firstRest",
+                                                            position: Position(
+                                                                PositionInner {
+                                                                    path: "",
+                                                                    line_number: 1,
+                                                                    column_number: 1,
+                                                                    line: "",
+                                                                },
+                                                            ),
+                                                        },
+                                                    ),
+                                                ),
+                                                rhs: None(
+                                                    None {
+                                                        position: Position(
+                                                            PositionInner {
+                                                                path: "",
+                                                                line_number: 1,
+                                                                column_number: 1,
+                                                                line: "",
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                                position: Position(
+                                                    PositionInner {
+                                                        path: "",
+                                                        line_number: 1,
+                                                        column_number: 1,
+                                                        line: "",
+                                                    },
+                                                ),
                                             },
-                                        },
+                                        ),
                                     ),
-                                ],
-                                result: Union(
-                                    Union {
-                                        lhs: Reference(
-                                            Reference {
-                                                name: "firstRest",
-                                                position: Position {
-                                                    path: "",
-                                                    line_number: 1,
-                                                    column_number: 1,
-                                                    line: "",
-                                                },
-                                            },
-                                        ),
-                                        rhs: None(
-                                            None {
-                                                position: Position {
-                                                    path: "",
-                                                    line_number: 1,
-                                                    column_number: 1,
-                                                    line: "",
-                                                },
-                                            },
-                                        ),
-                                        position: Position {
+                                    position: Position(
+                                        PositionInner {
                                             path: "",
                                             line_number: 1,
                                             column_number: 1,
                                             line: "",
                                         },
-                                    },
-                                ),
-                                position: Position {
-                                    path: "",
-                                    line_number: 1,
-                                    column_number: 1,
-                                    line: "",
+                                    ),
                                 },
-                            },
+                            ),
                         ),
                     ),
                     function: Variable(
                         Variable {
                             name: "deconstruct",
-                            position: Position {
-                                path: "",
-                                line_number: 1,
-                                column_number: 1,
-                                line: "",
-                            },
+                            position: Position(
+                                PositionInner {
+                                    path: "",
+                                    line_number: 1,
+                                    column_number: 1,
+                                    line: "",
+                                },
+                            ),
                         },
                     ),
                     arguments: [
                         Variable(
                             Variable {
                                 name: "xs",
-                                position: Position {
-                                    path: "",
-                                    line_number: 1,
-                                    column_number: 1,
-                                    line: "",
-                                },
+                                position: Position(
+                                    PositionInner {
+                                        path: "",
+                                        line_number: 1,
+                                        column_number: 1,
+                                        line: "",
+                                    },
+                                ),
                             },
                         ),
                     ],
-                    position: Position {
-                        path: "",
-                        line_number: 1,
-                        column_number: 1,
-                        line: "",
-                    },
+                    position: Position(
+                        PositionInner {
+                            path: "",
+                            line_number: 1,
+                            column_number: 1,
+                            line: "",
+                        },
+                    ),
                 },
             ),
             branches: [
                 IfTypeBranch {
                     type_: Reference(
-                        Reference {
-                            name: "firstRest",
-                            position: Position {
-                                path: "",
-                                line_number: 1,
-                                column_number: 1,
-                                line: "",
+                        Reference(
+                            ReferenceInner {
+                                name: "firstRest",
+                                position: Position(
+                                    PositionInner {
+                                        path: "",
+                                        line_number: 1,
+                                        column_number: 1,
+                                        line: "",
+                                    },
+                                ),
                             },
-                        },
+                        ),
                     ),
                     expression: Let(
                         Let {
@@ -116,105 +144,131 @@ Ok(
                             ),
                             type_: Some(
                                 Function(
-                                    Function {
-                                        arguments: [],
-                                        result: Any(
-                                            Any {
-                                                position: Position {
+                                    Function(
+                                        FunctionInner {
+                                            arguments: [],
+                                            result: Any(
+                                                Any {
+                                                    position: Position(
+                                                        PositionInner {
+                                                            path: "",
+                                                            line_number: 1,
+                                                            column_number: 1,
+                                                            line: "",
+                                                        },
+                                                    ),
+                                                },
+                                            ),
+                                            position: Position(
+                                                PositionInner {
                                                     path: "",
                                                     line_number: 1,
                                                     column_number: 1,
                                                     line: "",
                                                 },
-                                            },
-                                        ),
-                                        position: Position {
-                                            path: "",
-                                            line_number: 1,
-                                            column_number: 1,
-                                            line: "",
+                                            ),
                                         },
-                                    },
+                                    ),
                                 ),
                             ),
                             bound_expression: Call(
                                 Call {
                                     function_type: Some(
                                         Function(
-                                            Function {
-                                                arguments: [
-                                                    Reference(
-                                                        Reference {
-                                                            name: "firstRest",
-                                                            position: Position {
-                                                                path: "",
-                                                                line_number: 1,
-                                                                column_number: 1,
-                                                                line: "",
-                                                            },
-                                                        },
-                                                    ),
-                                                ],
-                                                result: Function(
-                                                    Function {
-                                                        arguments: [],
-                                                        result: Any(
-                                                            Any {
-                                                                position: Position {
-                                                                    path: "",
-                                                                    line_number: 1,
-                                                                    column_number: 1,
-                                                                    line: "",
+                                            Function(
+                                                FunctionInner {
+                                                    arguments: [
+                                                        Reference(
+                                                            Reference(
+                                                                ReferenceInner {
+                                                                    name: "firstRest",
+                                                                    position: Position(
+                                                                        PositionInner {
+                                                                            path: "",
+                                                                            line_number: 1,
+                                                                            column_number: 1,
+                                                                            line: "",
+                                                                        },
+                                                                    ),
                                                                 },
+                                                            ),
+                                                        ),
+                                                    ],
+                                                    result: Function(
+                                                        Function(
+                                                            FunctionInner {
+                                                                arguments: [],
+                                                                result: Any(
+                                                                    Any {
+                                                                        position: Position(
+                                                                            PositionInner {
+                                                                                path: "",
+                                                                                line_number: 1,
+                                                                                column_number: 1,
+                                                                                line: "",
+                                                                            },
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                                position: Position(
+                                                                    PositionInner {
+                                                                        path: "",
+                                                                        line_number: 1,
+                                                                        column_number: 1,
+                                                                        line: "",
+                                                                    },
+                                                                ),
                                                             },
                                                         ),
-                                                        position: Position {
+                                                    ),
+                                                    position: Position(
+                                                        PositionInner {
                                                             path: "",
                                                             line_number: 1,
                                                             column_number: 1,
                                                             line: "",
                                                         },
-                                                    },
-                                                ),
-                                                position: Position {
-                                                    path: "",
-                                                    line_number: 1,
-                                                    column_number: 1,
-                                                    line: "",
+                                                    ),
                                                 },
-                                            },
+                                            ),
                                         ),
                                     ),
                                     function: Variable(
                                         Variable {
                                             name: "first",
-                                            position: Position {
-                                                path: "",
-                                                line_number: 1,
-                                                column_number: 1,
-                                                line: "",
-                                            },
+                                            position: Position(
+                                                PositionInner {
+                                                    path: "",
+                                                    line_number: 1,
+                                                    column_number: 1,
+                                                    line: "",
+                                                },
+                                            ),
                                         },
                                     ),
                                     arguments: [
                                         Variable(
                                             Variable {
                                                 name: "$firstRest",
-                                                position: Position {
-                                                    path: "",
-                                                    line_number: 1,
-                                                    column_number: 1,
-                                                    line: "",
-                                                },
+                                                position: Position(
+                                                    PositionInner {
+                                                        path: "",
+                                                        line_number: 1,
+                                                        column_number: 1,
+                                                        line: "",
+                                                    },
+                                                ),
                                             },
                                         ),
                                     ],
-                                    position: Position {
-                                        path: "",
-                                        line_number: 1,
-                                        column_number: 1,
-                                        line: "",
-                                    },
+                                    position: Position(
+                                        PositionInner {
+                                            path: "",
+                                            line_number: 1,
+                                            column_number: 1,
+                                            line: "",
+                                        },
+                                    ),
                                 },
                             ),
                             expression: Let(
@@ -224,144 +278,178 @@ Ok(
                                     ),
                                     type_: Some(
                                         Reference(
-                                            Reference {
-                                                name: "anyList",
-                                                position: Position {
-                                                    path: "",
-                                                    line_number: 1,
-                                                    column_number: 1,
-                                                    line: "",
+                                            Reference(
+                                                ReferenceInner {
+                                                    name: "anyList",
+                                                    position: Position(
+                                                        PositionInner {
+                                                            path: "",
+                                                            line_number: 1,
+                                                            column_number: 1,
+                                                            line: "",
+                                                        },
+                                                    ),
                                                 },
-                                            },
+                                            ),
                                         ),
                                     ),
                                     bound_expression: Call(
                                         Call {
                                             function_type: Some(
                                                 Function(
-                                                    Function {
-                                                        arguments: [
-                                                            Reference(
-                                                                Reference {
-                                                                    name: "firstRest",
-                                                                    position: Position {
-                                                                        path: "",
-                                                                        line_number: 1,
-                                                                        column_number: 1,
-                                                                        line: "",
+                                                    Function(
+                                                        FunctionInner {
+                                                            arguments: [
+                                                                Reference(
+                                                                    Reference(
+                                                                        ReferenceInner {
+                                                                            name: "firstRest",
+                                                                            position: Position(
+                                                                                PositionInner {
+                                                                                    path: "",
+                                                                                    line_number: 1,
+                                                                                    column_number: 1,
+                                                                                    line: "",
+                                                                                },
+                                                                            ),
+                                                                        },
+                                                                    ),
+                                                                ),
+                                                            ],
+                                                            result: Reference(
+                                                                Reference(
+                                                                    ReferenceInner {
+                                                                        name: "anyList",
+                                                                        position: Position(
+                                                                            PositionInner {
+                                                                                path: "",
+                                                                                line_number: 1,
+                                                                                column_number: 1,
+                                                                                line: "",
+                                                                            },
+                                                                        ),
                                                                     },
-                                                                },
+                                                                ),
                                                             ),
-                                                        ],
-                                                        result: Reference(
-                                                            Reference {
-                                                                name: "anyList",
-                                                                position: Position {
+                                                            position: Position(
+                                                                PositionInner {
                                                                     path: "",
                                                                     line_number: 1,
                                                                     column_number: 1,
                                                                     line: "",
                                                                 },
-                                                            },
-                                                        ),
-                                                        position: Position {
-                                                            path: "",
-                                                            line_number: 1,
-                                                            column_number: 1,
-                                                            line: "",
+                                                            ),
                                                         },
-                                                    },
+                                                    ),
                                                 ),
                                             ),
                                             function: Variable(
                                                 Variable {
                                                     name: "rest",
-                                                    position: Position {
-                                                        path: "",
-                                                        line_number: 1,
-                                                        column_number: 1,
-                                                        line: "",
-                                                    },
+                                                    position: Position(
+                                                        PositionInner {
+                                                            path: "",
+                                                            line_number: 1,
+                                                            column_number: 1,
+                                                            line: "",
+                                                        },
+                                                    ),
                                                 },
                                             ),
                                             arguments: [
                                                 Variable(
                                                     Variable {
                                                         name: "$firstRest",
-                                                        position: Position {
-                                                            path: "",
-                                                            line_number: 1,
-                                                            column_number: 1,
-                                                            line: "",
-                                                        },
+                                                        position: Position(
+                                                            PositionInner {
+                                                                path: "",
+                                                                line_number: 1,
+                                                                column_number: 1,
+                                                                line: "",
+                                                            },
+                                                        ),
                                                     },
                                                 ),
                                             ],
-                                            position: Position {
-                                                path: "",
-                                                line_number: 1,
-                                                column_number: 1,
-                                                line: "",
-                                            },
+                                            position: Position(
+                                                PositionInner {
+                                                    path: "",
+                                                    line_number: 1,
+                                                    column_number: 1,
+                                                    line: "",
+                                                },
+                                            ),
                                         },
                                     ),
                                     expression: None(
                                         None {
-                                            position: Position {
-                                                path: "",
-                                                line_number: 1,
-                                                column_number: 1,
-                                                line: "",
-                                            },
+                                            position: Position(
+                                                PositionInner {
+                                                    path: "",
+                                                    line_number: 1,
+                                                    column_number: 1,
+                                                    line: "",
+                                                },
+                                            ),
                                         },
                                     ),
-                                    position: Position {
-                                        path: "",
-                                        line_number: 1,
-                                        column_number: 1,
-                                        line: "",
-                                    },
+                                    position: Position(
+                                        PositionInner {
+                                            path: "",
+                                            line_number: 1,
+                                            column_number: 1,
+                                            line: "",
+                                        },
+                                    ),
                                 },
                             ),
-                            position: Position {
-                                path: "",
-                                line_number: 1,
-                                column_number: 1,
-                                line: "",
-                            },
+                            position: Position(
+                                PositionInner {
+                                    path: "",
+                                    line_number: 1,
+                                    column_number: 1,
+                                    line: "",
+                                },
+                            ),
                         },
                     ),
                 },
                 IfTypeBranch {
                     type_: None(
                         None {
-                            position: Position {
-                                path: "",
-                                line_number: 1,
-                                column_number: 1,
-                                line: "",
-                            },
+                            position: Position(
+                                PositionInner {
+                                    path: "",
+                                    line_number: 1,
+                                    column_number: 1,
+                                    line: "",
+                                },
+                            ),
                         },
                     ),
                     expression: None(
                         None {
-                            position: Position {
-                                path: "",
-                                line_number: 1,
-                                column_number: 1,
-                                line: "",
-                            },
+                            position: Position(
+                                PositionInner {
+                                    path: "",
+                                    line_number: 1,
+                                    column_number: 1,
+                                    line: "",
+                                },
+                            ),
                         },
                     ),
                 },
             ],
             else_: None,
-            position: Position {
-                path: "",
-                line_number: 1,
-                column_number: 1,
-                line: "",
-            },
+            position: Position(
+                PositionInner {
+                    path: "",
+                    line_number: 1,
+                    column_number: 1,
+                    line: "",
+                },
+            ),
         },
     ),
 )

--- a/lib/hir-mir/src/transformation/snapshots/hir_mir__transformation__if_list__tests__transform_if_list_with_number_type.snap
+++ b/lib/hir-mir/src/transformation/snapshots/hir_mir__transformation__if_list__tests__transform_if_list_with_number_type.snap
@@ -10,104 +10,132 @@ Ok(
                 Call {
                     function_type: Some(
                         Function(
-                            Function {
-                                arguments: [
-                                    Reference(
-                                        Reference {
-                                            name: "anyList",
-                                            position: Position {
-                                                path: "",
-                                                line_number: 1,
-                                                column_number: 1,
-                                                line: "",
+                            Function(
+                                FunctionInner {
+                                    arguments: [
+                                        Reference(
+                                            Reference(
+                                                ReferenceInner {
+                                                    name: "anyList",
+                                                    position: Position(
+                                                        PositionInner {
+                                                            path: "",
+                                                            line_number: 1,
+                                                            column_number: 1,
+                                                            line: "",
+                                                        },
+                                                    ),
+                                                },
+                                            ),
+                                        ),
+                                    ],
+                                    result: Union(
+                                        Union(
+                                            UnionInner {
+                                                lhs: Reference(
+                                                    Reference(
+                                                        ReferenceInner {
+                                                            name: "firstRest",
+                                                            position: Position(
+                                                                PositionInner {
+                                                                    path: "",
+                                                                    line_number: 1,
+                                                                    column_number: 1,
+                                                                    line: "",
+                                                                },
+                                                            ),
+                                                        },
+                                                    ),
+                                                ),
+                                                rhs: None(
+                                                    None {
+                                                        position: Position(
+                                                            PositionInner {
+                                                                path: "",
+                                                                line_number: 1,
+                                                                column_number: 1,
+                                                                line: "",
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                                position: Position(
+                                                    PositionInner {
+                                                        path: "",
+                                                        line_number: 1,
+                                                        column_number: 1,
+                                                        line: "",
+                                                    },
+                                                ),
                                             },
-                                        },
+                                        ),
                                     ),
-                                ],
-                                result: Union(
-                                    Union {
-                                        lhs: Reference(
-                                            Reference {
-                                                name: "firstRest",
-                                                position: Position {
-                                                    path: "",
-                                                    line_number: 1,
-                                                    column_number: 1,
-                                                    line: "",
-                                                },
-                                            },
-                                        ),
-                                        rhs: None(
-                                            None {
-                                                position: Position {
-                                                    path: "",
-                                                    line_number: 1,
-                                                    column_number: 1,
-                                                    line: "",
-                                                },
-                                            },
-                                        ),
-                                        position: Position {
+                                    position: Position(
+                                        PositionInner {
                                             path: "",
                                             line_number: 1,
                                             column_number: 1,
                                             line: "",
                                         },
-                                    },
-                                ),
-                                position: Position {
-                                    path: "",
-                                    line_number: 1,
-                                    column_number: 1,
-                                    line: "",
+                                    ),
                                 },
-                            },
+                            ),
                         ),
                     ),
                     function: Variable(
                         Variable {
                             name: "deconstruct",
-                            position: Position {
-                                path: "",
-                                line_number: 1,
-                                column_number: 1,
-                                line: "",
-                            },
+                            position: Position(
+                                PositionInner {
+                                    path: "",
+                                    line_number: 1,
+                                    column_number: 1,
+                                    line: "",
+                                },
+                            ),
                         },
                     ),
                     arguments: [
                         Variable(
                             Variable {
                                 name: "xs",
-                                position: Position {
-                                    path: "",
-                                    line_number: 1,
-                                    column_number: 1,
-                                    line: "",
-                                },
+                                position: Position(
+                                    PositionInner {
+                                        path: "",
+                                        line_number: 1,
+                                        column_number: 1,
+                                        line: "",
+                                    },
+                                ),
                             },
                         ),
                     ],
-                    position: Position {
-                        path: "",
-                        line_number: 1,
-                        column_number: 1,
-                        line: "",
-                    },
+                    position: Position(
+                        PositionInner {
+                            path: "",
+                            line_number: 1,
+                            column_number: 1,
+                            line: "",
+                        },
+                    ),
                 },
             ),
             branches: [
                 IfTypeBranch {
                     type_: Reference(
-                        Reference {
-                            name: "firstRest",
-                            position: Position {
-                                path: "",
-                                line_number: 1,
-                                column_number: 1,
-                                line: "",
+                        Reference(
+                            ReferenceInner {
+                                name: "firstRest",
+                                position: Position(
+                                    PositionInner {
+                                        path: "",
+                                        line_number: 1,
+                                        column_number: 1,
+                                        line: "",
+                                    },
+                                ),
                             },
-                        },
+                        ),
                     ),
                     expression: Let(
                         Let {
@@ -116,25 +144,31 @@ Ok(
                             ),
                             type_: Some(
                                 Function(
-                                    Function {
-                                        arguments: [],
-                                        result: Number(
-                                            Number {
-                                                position: Position {
+                                    Function(
+                                        FunctionInner {
+                                            arguments: [],
+                                            result: Number(
+                                                Number {
+                                                    position: Position(
+                                                        PositionInner {
+                                                            path: "",
+                                                            line_number: 1,
+                                                            column_number: 1,
+                                                            line: "",
+                                                        },
+                                                    ),
+                                                },
+                                            ),
+                                            position: Position(
+                                                PositionInner {
                                                     path: "",
                                                     line_number: 1,
                                                     column_number: 1,
                                                     line: "",
                                                 },
-                                            },
-                                        ),
-                                        position: Position {
-                                            path: "",
-                                            line_number: 1,
-                                            column_number: 1,
-                                            line: "",
+                                            ),
                                         },
-                                    },
+                                    ),
                                 ),
                             ),
                             bound_expression: Let(
@@ -144,105 +178,131 @@ Ok(
                                     ),
                                     type_: Some(
                                         Function(
-                                            Function {
-                                                arguments: [],
-                                                result: Any(
-                                                    Any {
-                                                        position: Position {
+                                            Function(
+                                                FunctionInner {
+                                                    arguments: [],
+                                                    result: Any(
+                                                        Any {
+                                                            position: Position(
+                                                                PositionInner {
+                                                                    path: "",
+                                                                    line_number: 1,
+                                                                    column_number: 1,
+                                                                    line: "",
+                                                                },
+                                                            ),
+                                                        },
+                                                    ),
+                                                    position: Position(
+                                                        PositionInner {
                                                             path: "",
                                                             line_number: 1,
                                                             column_number: 1,
                                                             line: "",
                                                         },
-                                                    },
-                                                ),
-                                                position: Position {
-                                                    path: "",
-                                                    line_number: 1,
-                                                    column_number: 1,
-                                                    line: "",
+                                                    ),
                                                 },
-                                            },
+                                            ),
                                         ),
                                     ),
                                     bound_expression: Call(
                                         Call {
                                             function_type: Some(
                                                 Function(
-                                                    Function {
-                                                        arguments: [
-                                                            Reference(
-                                                                Reference {
-                                                                    name: "firstRest",
-                                                                    position: Position {
-                                                                        path: "",
-                                                                        line_number: 1,
-                                                                        column_number: 1,
-                                                                        line: "",
-                                                                    },
-                                                                },
-                                                            ),
-                                                        ],
-                                                        result: Function(
-                                                            Function {
-                                                                arguments: [],
-                                                                result: Any(
-                                                                    Any {
-                                                                        position: Position {
-                                                                            path: "",
-                                                                            line_number: 1,
-                                                                            column_number: 1,
-                                                                            line: "",
+                                                    Function(
+                                                        FunctionInner {
+                                                            arguments: [
+                                                                Reference(
+                                                                    Reference(
+                                                                        ReferenceInner {
+                                                                            name: "firstRest",
+                                                                            position: Position(
+                                                                                PositionInner {
+                                                                                    path: "",
+                                                                                    line_number: 1,
+                                                                                    column_number: 1,
+                                                                                    line: "",
+                                                                                },
+                                                                            ),
                                                                         },
+                                                                    ),
+                                                                ),
+                                                            ],
+                                                            result: Function(
+                                                                Function(
+                                                                    FunctionInner {
+                                                                        arguments: [],
+                                                                        result: Any(
+                                                                            Any {
+                                                                                position: Position(
+                                                                                    PositionInner {
+                                                                                        path: "",
+                                                                                        line_number: 1,
+                                                                                        column_number: 1,
+                                                                                        line: "",
+                                                                                    },
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                        position: Position(
+                                                                            PositionInner {
+                                                                                path: "",
+                                                                                line_number: 1,
+                                                                                column_number: 1,
+                                                                                line: "",
+                                                                            },
+                                                                        ),
                                                                     },
                                                                 ),
-                                                                position: Position {
+                                                            ),
+                                                            position: Position(
+                                                                PositionInner {
                                                                     path: "",
                                                                     line_number: 1,
                                                                     column_number: 1,
                                                                     line: "",
                                                                 },
-                                                            },
-                                                        ),
-                                                        position: Position {
-                                                            path: "",
-                                                            line_number: 1,
-                                                            column_number: 1,
-                                                            line: "",
+                                                            ),
                                                         },
-                                                    },
+                                                    ),
                                                 ),
                                             ),
                                             function: Variable(
                                                 Variable {
                                                     name: "first",
-                                                    position: Position {
-                                                        path: "",
-                                                        line_number: 1,
-                                                        column_number: 1,
-                                                        line: "",
-                                                    },
+                                                    position: Position(
+                                                        PositionInner {
+                                                            path: "",
+                                                            line_number: 1,
+                                                            column_number: 1,
+                                                            line: "",
+                                                        },
+                                                    ),
                                                 },
                                             ),
                                             arguments: [
                                                 Variable(
                                                     Variable {
                                                         name: "$firstRest",
-                                                        position: Position {
-                                                            path: "",
-                                                            line_number: 1,
-                                                            column_number: 1,
-                                                            line: "",
-                                                        },
+                                                        position: Position(
+                                                            PositionInner {
+                                                                path: "",
+                                                                line_number: 1,
+                                                                column_number: 1,
+                                                                line: "",
+                                                            },
+                                                        ),
                                                     },
                                                 ),
                                             ],
-                                            position: Position {
-                                                path: "",
-                                                line_number: 1,
-                                                column_number: 1,
-                                                line: "",
-                                            },
+                                            position: Position(
+                                                PositionInner {
+                                                    path: "",
+                                                    line_number: 1,
+                                                    column_number: 1,
+                                                    line: "",
+                                                },
+                                            ),
                                         },
                                     ),
                                     expression: Lambda(
@@ -250,12 +310,14 @@ Ok(
                                             arguments: [],
                                             result_type: Number(
                                                 Number {
-                                                    position: Position {
-                                                        path: "",
-                                                        line_number: 1,
-                                                        column_number: 1,
-                                                        line: "",
-                                                    },
+                                                    position: Position(
+                                                        PositionInner {
+                                                            path: "",
+                                                            line_number: 1,
+                                                            column_number: 1,
+                                                            line: "",
+                                                        },
+                                                    ),
                                                 },
                                             ),
                                             body: IfType(
@@ -265,95 +327,115 @@ Ok(
                                                         Call {
                                                             function_type: Some(
                                                                 Function(
-                                                                    Function {
-                                                                        arguments: [],
-                                                                        result: Any(
-                                                                            Any {
-                                                                                position: Position {
+                                                                    Function(
+                                                                        FunctionInner {
+                                                                            arguments: [],
+                                                                            result: Any(
+                                                                                Any {
+                                                                                    position: Position(
+                                                                                        PositionInner {
+                                                                                            path: "",
+                                                                                            line_number: 1,
+                                                                                            column_number: 1,
+                                                                                            line: "",
+                                                                                        },
+                                                                                    ),
+                                                                                },
+                                                                            ),
+                                                                            position: Position(
+                                                                                PositionInner {
                                                                                     path: "",
                                                                                     line_number: 1,
                                                                                     column_number: 1,
                                                                                     line: "",
                                                                                 },
-                                                                            },
-                                                                        ),
-                                                                        position: Position {
-                                                                            path: "",
-                                                                            line_number: 1,
-                                                                            column_number: 1,
-                                                                            line: "",
+                                                                            ),
                                                                         },
-                                                                    },
+                                                                    ),
                                                                 ),
                                                             ),
                                                             function: Variable(
                                                                 Variable {
                                                                     name: "x",
-                                                                    position: Position {
-                                                                        path: "",
-                                                                        line_number: 1,
-                                                                        column_number: 1,
-                                                                        line: "",
-                                                                    },
+                                                                    position: Position(
+                                                                        PositionInner {
+                                                                            path: "",
+                                                                            line_number: 1,
+                                                                            column_number: 1,
+                                                                            line: "",
+                                                                        },
+                                                                    ),
                                                                 },
                                                             ),
                                                             arguments: [],
-                                                            position: Position {
-                                                                path: "",
-                                                                line_number: 1,
-                                                                column_number: 1,
-                                                                line: "",
-                                                            },
+                                                            position: Position(
+                                                                PositionInner {
+                                                                    path: "",
+                                                                    line_number: 1,
+                                                                    column_number: 1,
+                                                                    line: "",
+                                                                },
+                                                            ),
                                                         },
                                                     ),
                                                     branches: [
                                                         IfTypeBranch {
                                                             type_: Number(
                                                                 Number {
-                                                                    position: Position {
-                                                                        path: "",
-                                                                        line_number: 1,
-                                                                        column_number: 1,
-                                                                        line: "",
-                                                                    },
+                                                                    position: Position(
+                                                                        PositionInner {
+                                                                            path: "",
+                                                                            line_number: 1,
+                                                                            column_number: 1,
+                                                                            line: "",
+                                                                        },
+                                                                    ),
                                                                 },
                                                             ),
                                                             expression: Variable(
                                                                 Variable {
                                                                     name: "$value",
-                                                                    position: Position {
-                                                                        path: "",
-                                                                        line_number: 1,
-                                                                        column_number: 1,
-                                                                        line: "",
-                                                                    },
+                                                                    position: Position(
+                                                                        PositionInner {
+                                                                            path: "",
+                                                                            line_number: 1,
+                                                                            column_number: 1,
+                                                                            line: "",
+                                                                        },
+                                                                    ),
                                                                 },
                                                             ),
                                                         },
                                                     ],
                                                     else_: None,
-                                                    position: Position {
-                                                        path: "",
-                                                        line_number: 1,
-                                                        column_number: 1,
-                                                        line: "",
-                                                    },
+                                                    position: Position(
+                                                        PositionInner {
+                                                            path: "",
+                                                            line_number: 1,
+                                                            column_number: 1,
+                                                            line: "",
+                                                        },
+                                                    ),
                                                 },
                                             ),
-                                            position: Position {
-                                                path: "",
-                                                line_number: 1,
-                                                column_number: 1,
-                                                line: "",
-                                            },
+                                            position: Position(
+                                                PositionInner {
+                                                    path: "",
+                                                    line_number: 1,
+                                                    column_number: 1,
+                                                    line: "",
+                                                },
+                                            ),
                                         },
                                     ),
-                                    position: Position {
-                                        path: "",
-                                        line_number: 1,
-                                        column_number: 1,
-                                        line: "",
-                                    },
+                                    position: Position(
+                                        PositionInner {
+                                            path: "",
+                                            line_number: 1,
+                                            column_number: 1,
+                                            line: "",
+                                        },
+                                    ),
                                 },
                             ),
                             expression: Let(
@@ -363,144 +445,178 @@ Ok(
                                     ),
                                     type_: Some(
                                         Reference(
-                                            Reference {
-                                                name: "anyList",
-                                                position: Position {
-                                                    path: "",
-                                                    line_number: 1,
-                                                    column_number: 1,
-                                                    line: "",
+                                            Reference(
+                                                ReferenceInner {
+                                                    name: "anyList",
+                                                    position: Position(
+                                                        PositionInner {
+                                                            path: "",
+                                                            line_number: 1,
+                                                            column_number: 1,
+                                                            line: "",
+                                                        },
+                                                    ),
                                                 },
-                                            },
+                                            ),
                                         ),
                                     ),
                                     bound_expression: Call(
                                         Call {
                                             function_type: Some(
                                                 Function(
-                                                    Function {
-                                                        arguments: [
-                                                            Reference(
-                                                                Reference {
-                                                                    name: "firstRest",
-                                                                    position: Position {
-                                                                        path: "",
-                                                                        line_number: 1,
-                                                                        column_number: 1,
-                                                                        line: "",
+                                                    Function(
+                                                        FunctionInner {
+                                                            arguments: [
+                                                                Reference(
+                                                                    Reference(
+                                                                        ReferenceInner {
+                                                                            name: "firstRest",
+                                                                            position: Position(
+                                                                                PositionInner {
+                                                                                    path: "",
+                                                                                    line_number: 1,
+                                                                                    column_number: 1,
+                                                                                    line: "",
+                                                                                },
+                                                                            ),
+                                                                        },
+                                                                    ),
+                                                                ),
+                                                            ],
+                                                            result: Reference(
+                                                                Reference(
+                                                                    ReferenceInner {
+                                                                        name: "anyList",
+                                                                        position: Position(
+                                                                            PositionInner {
+                                                                                path: "",
+                                                                                line_number: 1,
+                                                                                column_number: 1,
+                                                                                line: "",
+                                                                            },
+                                                                        ),
                                                                     },
-                                                                },
+                                                                ),
                                                             ),
-                                                        ],
-                                                        result: Reference(
-                                                            Reference {
-                                                                name: "anyList",
-                                                                position: Position {
+                                                            position: Position(
+                                                                PositionInner {
                                                                     path: "",
                                                                     line_number: 1,
                                                                     column_number: 1,
                                                                     line: "",
                                                                 },
-                                                            },
-                                                        ),
-                                                        position: Position {
-                                                            path: "",
-                                                            line_number: 1,
-                                                            column_number: 1,
-                                                            line: "",
+                                                            ),
                                                         },
-                                                    },
+                                                    ),
                                                 ),
                                             ),
                                             function: Variable(
                                                 Variable {
                                                     name: "rest",
-                                                    position: Position {
-                                                        path: "",
-                                                        line_number: 1,
-                                                        column_number: 1,
-                                                        line: "",
-                                                    },
+                                                    position: Position(
+                                                        PositionInner {
+                                                            path: "",
+                                                            line_number: 1,
+                                                            column_number: 1,
+                                                            line: "",
+                                                        },
+                                                    ),
                                                 },
                                             ),
                                             arguments: [
                                                 Variable(
                                                     Variable {
                                                         name: "$firstRest",
-                                                        position: Position {
-                                                            path: "",
-                                                            line_number: 1,
-                                                            column_number: 1,
-                                                            line: "",
-                                                        },
+                                                        position: Position(
+                                                            PositionInner {
+                                                                path: "",
+                                                                line_number: 1,
+                                                                column_number: 1,
+                                                                line: "",
+                                                            },
+                                                        ),
                                                     },
                                                 ),
                                             ],
-                                            position: Position {
-                                                path: "",
-                                                line_number: 1,
-                                                column_number: 1,
-                                                line: "",
-                                            },
+                                            position: Position(
+                                                PositionInner {
+                                                    path: "",
+                                                    line_number: 1,
+                                                    column_number: 1,
+                                                    line: "",
+                                                },
+                                            ),
                                         },
                                     ),
                                     expression: None(
                                         None {
-                                            position: Position {
-                                                path: "",
-                                                line_number: 1,
-                                                column_number: 1,
-                                                line: "",
-                                            },
+                                            position: Position(
+                                                PositionInner {
+                                                    path: "",
+                                                    line_number: 1,
+                                                    column_number: 1,
+                                                    line: "",
+                                                },
+                                            ),
                                         },
                                     ),
-                                    position: Position {
-                                        path: "",
-                                        line_number: 1,
-                                        column_number: 1,
-                                        line: "",
-                                    },
+                                    position: Position(
+                                        PositionInner {
+                                            path: "",
+                                            line_number: 1,
+                                            column_number: 1,
+                                            line: "",
+                                        },
+                                    ),
                                 },
                             ),
-                            position: Position {
-                                path: "",
-                                line_number: 1,
-                                column_number: 1,
-                                line: "",
-                            },
+                            position: Position(
+                                PositionInner {
+                                    path: "",
+                                    line_number: 1,
+                                    column_number: 1,
+                                    line: "",
+                                },
+                            ),
                         },
                     ),
                 },
                 IfTypeBranch {
                     type_: None(
                         None {
-                            position: Position {
-                                path: "",
-                                line_number: 1,
-                                column_number: 1,
-                                line: "",
-                            },
+                            position: Position(
+                                PositionInner {
+                                    path: "",
+                                    line_number: 1,
+                                    column_number: 1,
+                                    line: "",
+                                },
+                            ),
                         },
                     ),
                     expression: None(
                         None {
-                            position: Position {
-                                path: "",
-                                line_number: 1,
-                                column_number: 1,
-                                line: "",
-                            },
+                            position: Position(
+                                PositionInner {
+                                    path: "",
+                                    line_number: 1,
+                                    column_number: 1,
+                                    line: "",
+                                },
+                            ),
                         },
                     ),
                 },
             ],
             else_: None,
-            position: Position {
-                path: "",
-                line_number: 1,
-                column_number: 1,
-                line: "",
-            },
+            position: Position(
+                PositionInner {
+                    path: "",
+                    line_number: 1,
+                    column_number: 1,
+                    line: "",
+                },
+            ),
         },
     ),
 )

--- a/lib/hir-mir/src/transformation/snapshots/hir_mir__transformation__if_map__tests__transform_if_map.snap
+++ b/lib/hir-mir/src/transformation/snapshots/hir_mir__transformation__if_map__tests__transform_if_map.snap
@@ -10,69 +10,87 @@ Ok(
                 Call {
                     function_type: Some(
                         Function(
-                            Function {
-                                arguments: [
-                                    Reference(
-                                        Reference {
-                                            name: "mapContext",
-                                            position: Position {
-                                                path: "",
-                                                line_number: 1,
-                                                column_number: 1,
-                                                line: "",
+                            Function(
+                                FunctionInner {
+                                    arguments: [
+                                        Reference(
+                                            Reference(
+                                                ReferenceInner {
+                                                    name: "mapContext",
+                                                    position: Position(
+                                                        PositionInner {
+                                                            path: "",
+                                                            line_number: 1,
+                                                            column_number: 1,
+                                                            line: "",
+                                                        },
+                                                    ),
+                                                },
+                                            ),
+                                        ),
+                                        Reference(
+                                            Reference(
+                                                ReferenceInner {
+                                                    name: "genericMap",
+                                                    position: Position(
+                                                        PositionInner {
+                                                            path: "",
+                                                            line_number: 1,
+                                                            column_number: 1,
+                                                            line: "",
+                                                        },
+                                                    ),
+                                                },
+                                            ),
+                                        ),
+                                        Any(
+                                            Any {
+                                                position: Position(
+                                                    PositionInner {
+                                                        path: "",
+                                                        line_number: 1,
+                                                        column_number: 1,
+                                                        line: "",
+                                                    },
+                                                ),
                                             },
-                                        },
-                                    ),
-                                    Reference(
-                                        Reference {
-                                            name: "genericMap",
-                                            position: Position {
-                                                path: "",
-                                                line_number: 1,
-                                                column_number: 1,
-                                                line: "",
-                                            },
-                                        },
-                                    ),
-                                    Any(
+                                        ),
+                                    ],
+                                    result: Any(
                                         Any {
-                                            position: Position {
-                                                path: "",
-                                                line_number: 1,
-                                                column_number: 1,
-                                                line: "",
-                                            },
+                                            position: Position(
+                                                PositionInner {
+                                                    path: "",
+                                                    line_number: 1,
+                                                    column_number: 1,
+                                                    line: "",
+                                                },
+                                            ),
                                         },
                                     ),
-                                ],
-                                result: Any(
-                                    Any {
-                                        position: Position {
+                                    position: Position(
+                                        PositionInner {
                                             path: "",
                                             line_number: 1,
                                             column_number: 1,
                                             line: "",
                                         },
-                                    },
-                                ),
-                                position: Position {
-                                    path: "",
-                                    line_number: 1,
-                                    column_number: 1,
-                                    line: "",
+                                    ),
                                 },
-                            },
+                            ),
                         ),
                     ),
                     function: Variable(
                         Variable {
                             name: "getMap",
-                            position: Position {
-                                path: "",
-                                line_number: 1,
-                                column_number: 1,
-                                line: "",
-                            },
+                            position: Position(
+                                PositionInner {
+                                    path: "",
+                                    line_number: 1,
+                                    column_number: 1,
+                                    line: "",
+                                },
+                            ),
                         },
                     ),
                     arguments: [
@@ -80,130 +98,160 @@ Ok(
                             Call {
                                 function_type: Some(
                                     Function(
-                                        Function {
-                                            arguments: [],
-                                            result: Reference(
-                                                Reference {
-                                                    name: "mapContext",
-                                                    position: Position {
+                                        Function(
+                                            FunctionInner {
+                                                arguments: [],
+                                                result: Reference(
+                                                    Reference(
+                                                        ReferenceInner {
+                                                            name: "mapContext",
+                                                            position: Position(
+                                                                PositionInner {
+                                                                    path: "",
+                                                                    line_number: 1,
+                                                                    column_number: 1,
+                                                                    line: "",
+                                                                },
+                                                            ),
+                                                        },
+                                                    ),
+                                                ),
+                                                position: Position(
+                                                    PositionInner {
                                                         path: "",
                                                         line_number: 1,
                                                         column_number: 1,
                                                         line: "",
                                                     },
-                                                },
-                                            ),
-                                            position: Position {
-                                                path: "",
-                                                line_number: 1,
-                                                column_number: 1,
-                                                line: "",
+                                                ),
                                             },
-                                        },
+                                        ),
                                     ),
                                 ),
                                 function: Variable(
                                     Variable {
                                         name: "hir:map:context:eb72cf2d91bedd6c",
-                                        position: Position {
-                                            path: "",
-                                            line_number: 1,
-                                            column_number: 1,
-                                            line: "",
-                                        },
+                                        position: Position(
+                                            PositionInner {
+                                                path: "",
+                                                line_number: 1,
+                                                column_number: 1,
+                                                line: "",
+                                            },
+                                        ),
                                     },
                                 ),
                                 arguments: [],
-                                position: Position {
-                                    path: "",
-                                    line_number: 1,
-                                    column_number: 1,
-                                    line: "",
-                                },
+                                position: Position(
+                                    PositionInner {
+                                        path: "",
+                                        line_number: 1,
+                                        column_number: 1,
+                                        line: "",
+                                    },
+                                ),
                             },
                         ),
                         Variable(
                             Variable {
                                 name: "xs",
-                                position: Position {
-                                    path: "",
-                                    line_number: 1,
-                                    column_number: 1,
-                                    line: "",
-                                },
+                                position: Position(
+                                    PositionInner {
+                                        path: "",
+                                        line_number: 1,
+                                        column_number: 1,
+                                        line: "",
+                                    },
+                                ),
                             },
                         ),
                         TypeCoercion(
                             TypeCoercion {
                                 from: Number(
                                     Number {
-                                        position: Position {
-                                            path: "",
-                                            line_number: 1,
-                                            column_number: 1,
-                                            line: "",
-                                        },
+                                        position: Position(
+                                            PositionInner {
+                                                path: "",
+                                                line_number: 1,
+                                                column_number: 1,
+                                                line: "",
+                                            },
+                                        ),
                                     },
                                 ),
                                 to: Any(
                                     Any {
-                                        position: Position {
-                                            path: "",
-                                            line_number: 1,
-                                            column_number: 1,
-                                            line: "",
-                                        },
+                                        position: Position(
+                                            PositionInner {
+                                                path: "",
+                                                line_number: 1,
+                                                column_number: 1,
+                                                line: "",
+                                            },
+                                        ),
                                     },
                                 ),
                                 argument: Variable(
                                     Variable {
                                         name: "k",
-                                        position: Position {
-                                            path: "",
-                                            line_number: 1,
-                                            column_number: 1,
-                                            line: "",
-                                        },
+                                        position: Position(
+                                            PositionInner {
+                                                path: "",
+                                                line_number: 1,
+                                                column_number: 1,
+                                                line: "",
+                                            },
+                                        ),
                                     },
                                 ),
-                                position: Position {
-                                    path: "",
-                                    line_number: 1,
-                                    column_number: 1,
-                                    line: "",
-                                },
+                                position: Position(
+                                    PositionInner {
+                                        path: "",
+                                        line_number: 1,
+                                        column_number: 1,
+                                        line: "",
+                                    },
+                                ),
                             },
                         ),
                     ],
-                    position: Position {
-                        path: "",
-                        line_number: 1,
-                        column_number: 1,
-                        line: "",
-                    },
+                    position: Position(
+                        PositionInner {
+                            path: "",
+                            line_number: 1,
+                            column_number: 1,
+                            line: "",
+                        },
+                    ),
                 },
             ),
             branches: [
                 IfTypeBranch {
                     type_: Reference(
-                        Reference {
-                            name: "notFound",
-                            position: Position {
-                                path: "",
-                                line_number: 1,
-                                column_number: 1,
-                                line: "",
+                        Reference(
+                            ReferenceInner {
+                                name: "notFound",
+                                position: Position(
+                                    PositionInner {
+                                        path: "",
+                                        line_number: 1,
+                                        column_number: 1,
+                                        line: "",
+                                    },
+                                ),
                             },
-                        },
+                        ),
                     ),
                     expression: None(
                         None {
-                            position: Position {
-                                path: "",
-                                line_number: 1,
-                                column_number: 1,
-                                line: "",
-                            },
+                            position: Position(
+                                PositionInner {
+                                    path: "",
+                                    line_number: 1,
+                                    column_number: 1,
+                                    line: "",
+                                },
+                            ),
                         },
                     ),
                 },
@@ -213,12 +261,14 @@ Ok(
                     type_: Some(
                         Any(
                             Any {
-                                position: Position {
-                                    path: "",
-                                    line_number: 1,
-                                    column_number: 1,
-                                    line: "",
-                                },
+                                position: Position(
+                                    PositionInner {
+                                        path: "",
+                                        line_number: 1,
+                                        column_number: 1,
+                                        line: "",
+                                    },
+                                ),
                             },
                         ),
                     ),
@@ -230,12 +280,14 @@ Ok(
                             type_: Some(
                                 None(
                                     None {
-                                        position: Position {
-                                            path: "",
-                                            line_number: 1,
-                                            column_number: 1,
-                                            line: "",
-                                        },
+                                        position: Position(
+                                            PositionInner {
+                                                path: "",
+                                                line_number: 1,
+                                                column_number: 1,
+                                                line: "",
+                                            },
+                                        ),
                                     },
                                 ),
                             ),
@@ -245,81 +297,97 @@ Ok(
                                     argument: Variable(
                                         Variable {
                                             name: "x",
-                                            position: Position {
-                                                path: "",
-                                                line_number: 1,
-                                                column_number: 1,
-                                                line: "",
-                                            },
+                                            position: Position(
+                                                PositionInner {
+                                                    path: "",
+                                                    line_number: 1,
+                                                    column_number: 1,
+                                                    line: "",
+                                                },
+                                            ),
                                         },
                                     ),
                                     branches: [
                                         IfTypeBranch {
                                             type_: None(
                                                 None {
-                                                    position: Position {
-                                                        path: "",
-                                                        line_number: 1,
-                                                        column_number: 1,
-                                                        line: "",
-                                                    },
+                                                    position: Position(
+                                                        PositionInner {
+                                                            path: "",
+                                                            line_number: 1,
+                                                            column_number: 1,
+                                                            line: "",
+                                                        },
+                                                    ),
                                                 },
                                             ),
                                             expression: Variable(
                                                 Variable {
                                                     name: "$value",
-                                                    position: Position {
-                                                        path: "",
-                                                        line_number: 1,
-                                                        column_number: 1,
-                                                        line: "",
-                                                    },
+                                                    position: Position(
+                                                        PositionInner {
+                                                            path: "",
+                                                            line_number: 1,
+                                                            column_number: 1,
+                                                            line: "",
+                                                        },
+                                                    ),
                                                 },
                                             ),
                                         },
                                     ],
                                     else_: None,
-                                    position: Position {
-                                        path: "",
-                                        line_number: 1,
-                                        column_number: 1,
-                                        line: "",
-                                    },
+                                    position: Position(
+                                        PositionInner {
+                                            path: "",
+                                            line_number: 1,
+                                            column_number: 1,
+                                            line: "",
+                                        },
+                                    ),
                                 },
                             ),
                             expression: Variable(
                                 Variable {
                                     name: "x",
-                                    position: Position {
-                                        path: "",
-                                        line_number: 1,
-                                        column_number: 1,
-                                        line: "",
-                                    },
+                                    position: Position(
+                                        PositionInner {
+                                            path: "",
+                                            line_number: 1,
+                                            column_number: 1,
+                                            line: "",
+                                        },
+                                    ),
                                 },
                             ),
-                            position: Position {
-                                path: "",
-                                line_number: 1,
-                                column_number: 1,
-                                line: "",
-                            },
+                            position: Position(
+                                PositionInner {
+                                    path: "",
+                                    line_number: 1,
+                                    column_number: 1,
+                                    line: "",
+                                },
+                            ),
                         },
                     ),
-                    position: Position {
-                        path: "",
-                        line_number: 1,
-                        column_number: 1,
-                        line: "",
-                    },
+                    position: Position(
+                        PositionInner {
+                            path: "",
+                            line_number: 1,
+                            column_number: 1,
+                            line: "",
+                        },
+                    ),
                 },
             ),
-            position: Position {
-                path: "",
-                line_number: 1,
-                column_number: 1,
-                line: "",
-            },
+            position: Position(
+                PositionInner {
+                    path: "",
+                    line_number: 1,
+                    column_number: 1,
+                    line: "",
+                },
+            ),
         },
     ),
 )

--- a/lib/hir-mir/src/transformation/snapshots/hir_mir__transformation__map_literal__tests__transform_empty_map.snap
+++ b/lib/hir-mir/src/transformation/snapshots/hir_mir__transformation__map_literal__tests__transform_empty_map.snap
@@ -10,115 +10,145 @@ Ok(
             ),
             type_: Some(
                 Reference(
-                    Reference {
-                        name: "mapContext",
-                        position: Position {
-                            path: "",
-                            line_number: 1,
-                            column_number: 1,
-                            line: "",
+                    Reference(
+                        ReferenceInner {
+                            name: "mapContext",
+                            position: Position(
+                                PositionInner {
+                                    path: "",
+                                    line_number: 1,
+                                    column_number: 1,
+                                    line: "",
+                                },
+                            ),
                         },
-                    },
+                    ),
                 ),
             ),
             bound_expression: Call(
                 Call {
                     function_type: Some(
                         Function(
-                            Function {
-                                arguments: [],
-                                result: Reference(
-                                    Reference {
-                                        name: "mapContext",
-                                        position: Position {
+                            Function(
+                                FunctionInner {
+                                    arguments: [],
+                                    result: Reference(
+                                        Reference(
+                                            ReferenceInner {
+                                                name: "mapContext",
+                                                position: Position(
+                                                    PositionInner {
+                                                        path: "",
+                                                        line_number: 1,
+                                                        column_number: 1,
+                                                        line: "",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                    position: Position(
+                                        PositionInner {
                                             path: "",
                                             line_number: 1,
                                             column_number: 1,
                                             line: "",
                                         },
-                                    },
-                                ),
-                                position: Position {
-                                    path: "",
-                                    line_number: 1,
-                                    column_number: 1,
-                                    line: "",
+                                    ),
                                 },
-                            },
+                            ),
                         ),
                     ),
                     function: Variable(
                         Variable {
                             name: "hir:map:context:829f738c8f9ee2f4",
-                            position: Position {
-                                path: "",
-                                line_number: 1,
-                                column_number: 1,
-                                line: "",
-                            },
+                            position: Position(
+                                PositionInner {
+                                    path: "",
+                                    line_number: 1,
+                                    column_number: 1,
+                                    line: "",
+                                },
+                            ),
                         },
                     ),
                     arguments: [],
-                    position: Position {
-                        path: "",
-                        line_number: 1,
-                        column_number: 1,
-                        line: "",
-                    },
+                    position: Position(
+                        PositionInner {
+                            path: "",
+                            line_number: 1,
+                            column_number: 1,
+                            line: "",
+                        },
+                    ),
                 },
             ),
             expression: Call(
                 Call {
                     function_type: Some(
                         Function(
-                            Function {
-                                arguments: [],
-                                result: Reference(
-                                    Reference {
-                                        name: "genericMap",
-                                        position: Position {
+                            Function(
+                                FunctionInner {
+                                    arguments: [],
+                                    result: Reference(
+                                        Reference(
+                                            ReferenceInner {
+                                                name: "genericMap",
+                                                position: Position(
+                                                    PositionInner {
+                                                        path: "",
+                                                        line_number: 1,
+                                                        column_number: 1,
+                                                        line: "",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                    position: Position(
+                                        PositionInner {
                                             path: "",
                                             line_number: 1,
                                             column_number: 1,
                                             line: "",
                                         },
-                                    },
-                                ),
-                                position: Position {
-                                    path: "",
-                                    line_number: 1,
-                                    column_number: 1,
-                                    line: "",
+                                    ),
                                 },
-                            },
+                            ),
                         ),
                     ),
                     function: Variable(
                         Variable {
                             name: "emptyMap",
-                            position: Position {
-                                path: "",
-                                line_number: 1,
-                                column_number: 1,
-                                line: "",
-                            },
+                            position: Position(
+                                PositionInner {
+                                    path: "",
+                                    line_number: 1,
+                                    column_number: 1,
+                                    line: "",
+                                },
+                            ),
                         },
                     ),
                     arguments: [],
-                    position: Position {
-                        path: "",
-                        line_number: 1,
-                        column_number: 1,
-                        line: "",
-                    },
+                    position: Position(
+                        PositionInner {
+                            path: "",
+                            line_number: 1,
+                            column_number: 1,
+                            line: "",
+                        },
+                    ),
                 },
             ),
-            position: Position {
-                path: "",
-                line_number: 1,
-                column_number: 1,
-                line: "",
-            },
+            position: Position(
+                PositionInner {
+                    path: "",
+                    line_number: 1,
+                    column_number: 1,
+                    line: "",
+                },
+            ),
         },
     ),
 )

--- a/lib/hir-mir/src/transformation/snapshots/hir_mir__transformation__map_literal__tests__transform_empty_map_with_function_value.snap
+++ b/lib/hir-mir/src/transformation/snapshots/hir_mir__transformation__map_literal__tests__transform_empty_map_with_function_value.snap
@@ -10,115 +10,145 @@ Ok(
             ),
             type_: Some(
                 Reference(
-                    Reference {
-                        name: "mapContext",
-                        position: Position {
-                            path: "",
-                            line_number: 1,
-                            column_number: 1,
-                            line: "",
+                    Reference(
+                        ReferenceInner {
+                            name: "mapContext",
+                            position: Position(
+                                PositionInner {
+                                    path: "",
+                                    line_number: 1,
+                                    column_number: 1,
+                                    line: "",
+                                },
+                            ),
                         },
-                    },
+                    ),
                 ),
             ),
             bound_expression: Call(
                 Call {
                     function_type: Some(
                         Function(
-                            Function {
-                                arguments: [],
-                                result: Reference(
-                                    Reference {
-                                        name: "mapContext",
-                                        position: Position {
+                            Function(
+                                FunctionInner {
+                                    arguments: [],
+                                    result: Reference(
+                                        Reference(
+                                            ReferenceInner {
+                                                name: "mapContext",
+                                                position: Position(
+                                                    PositionInner {
+                                                        path: "",
+                                                        line_number: 1,
+                                                        column_number: 1,
+                                                        line: "",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                    position: Position(
+                                        PositionInner {
                                             path: "",
                                             line_number: 1,
                                             column_number: 1,
                                             line: "",
                                         },
-                                    },
-                                ),
-                                position: Position {
-                                    path: "",
-                                    line_number: 1,
-                                    column_number: 1,
-                                    line: "",
+                                    ),
                                 },
-                            },
+                            ),
                         ),
                     ),
                     function: Variable(
                         Variable {
                             name: "hir:map:context:8bbb62926defb736",
-                            position: Position {
-                                path: "",
-                                line_number: 1,
-                                column_number: 1,
-                                line: "",
-                            },
+                            position: Position(
+                                PositionInner {
+                                    path: "",
+                                    line_number: 1,
+                                    column_number: 1,
+                                    line: "",
+                                },
+                            ),
                         },
                     ),
                     arguments: [],
-                    position: Position {
-                        path: "",
-                        line_number: 1,
-                        column_number: 1,
-                        line: "",
-                    },
+                    position: Position(
+                        PositionInner {
+                            path: "",
+                            line_number: 1,
+                            column_number: 1,
+                            line: "",
+                        },
+                    ),
                 },
             ),
             expression: Call(
                 Call {
                     function_type: Some(
                         Function(
-                            Function {
-                                arguments: [],
-                                result: Reference(
-                                    Reference {
-                                        name: "genericMap",
-                                        position: Position {
+                            Function(
+                                FunctionInner {
+                                    arguments: [],
+                                    result: Reference(
+                                        Reference(
+                                            ReferenceInner {
+                                                name: "genericMap",
+                                                position: Position(
+                                                    PositionInner {
+                                                        path: "",
+                                                        line_number: 1,
+                                                        column_number: 1,
+                                                        line: "",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                    position: Position(
+                                        PositionInner {
                                             path: "",
                                             line_number: 1,
                                             column_number: 1,
                                             line: "",
                                         },
-                                    },
-                                ),
-                                position: Position {
-                                    path: "",
-                                    line_number: 1,
-                                    column_number: 1,
-                                    line: "",
+                                    ),
                                 },
-                            },
+                            ),
                         ),
                     ),
                     function: Variable(
                         Variable {
                             name: "emptyMap",
-                            position: Position {
-                                path: "",
-                                line_number: 1,
-                                column_number: 1,
-                                line: "",
-                            },
+                            position: Position(
+                                PositionInner {
+                                    path: "",
+                                    line_number: 1,
+                                    column_number: 1,
+                                    line: "",
+                                },
+                            ),
                         },
                     ),
                     arguments: [],
-                    position: Position {
-                        path: "",
-                        line_number: 1,
-                        column_number: 1,
-                        line: "",
-                    },
+                    position: Position(
+                        PositionInner {
+                            path: "",
+                            line_number: 1,
+                            column_number: 1,
+                            line: "",
+                        },
+                    ),
                 },
             ),
-            position: Position {
-                path: "",
-                line_number: 1,
-                column_number: 1,
-                line: "",
-            },
+            position: Position(
+                PositionInner {
+                    path: "",
+                    line_number: 1,
+                    column_number: 1,
+                    line: "",
+                },
+            ),
         },
     ),
 )

--- a/lib/hir-mir/src/transformation/snapshots/hir_mir__transformation__map_literal__tests__transform_map_with_2_entries.snap
+++ b/lib/hir-mir/src/transformation/snapshots/hir_mir__transformation__map_literal__tests__transform_map_with_2_entries.snap
@@ -10,479 +10,593 @@ Ok(
             ),
             type_: Some(
                 Reference(
-                    Reference {
-                        name: "mapContext",
-                        position: Position {
-                            path: "",
-                            line_number: 1,
-                            column_number: 1,
-                            line: "",
+                    Reference(
+                        ReferenceInner {
+                            name: "mapContext",
+                            position: Position(
+                                PositionInner {
+                                    path: "",
+                                    line_number: 1,
+                                    column_number: 1,
+                                    line: "",
+                                },
+                            ),
                         },
-                    },
+                    ),
                 ),
             ),
             bound_expression: Call(
                 Call {
                     function_type: Some(
                         Function(
-                            Function {
-                                arguments: [],
-                                result: Reference(
-                                    Reference {
-                                        name: "mapContext",
-                                        position: Position {
+                            Function(
+                                FunctionInner {
+                                    arguments: [],
+                                    result: Reference(
+                                        Reference(
+                                            ReferenceInner {
+                                                name: "mapContext",
+                                                position: Position(
+                                                    PositionInner {
+                                                        path: "",
+                                                        line_number: 1,
+                                                        column_number: 1,
+                                                        line: "",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                    position: Position(
+                                        PositionInner {
                                             path: "",
                                             line_number: 1,
                                             column_number: 1,
                                             line: "",
                                         },
-                                    },
-                                ),
-                                position: Position {
-                                    path: "",
-                                    line_number: 1,
-                                    column_number: 1,
-                                    line: "",
+                                    ),
                                 },
-                            },
+                            ),
                         ),
                     ),
                     function: Variable(
                         Variable {
                             name: "hir:map:context:829f738c8f9ee2f4",
-                            position: Position {
-                                path: "",
-                                line_number: 1,
-                                column_number: 1,
-                                line: "",
-                            },
+                            position: Position(
+                                PositionInner {
+                                    path: "",
+                                    line_number: 1,
+                                    column_number: 1,
+                                    line: "",
+                                },
+                            ),
                         },
                     ),
                     arguments: [],
-                    position: Position {
-                        path: "",
-                        line_number: 1,
-                        column_number: 1,
-                        line: "",
-                    },
+                    position: Position(
+                        PositionInner {
+                            path: "",
+                            line_number: 1,
+                            column_number: 1,
+                            line: "",
+                        },
+                    ),
                 },
             ),
             expression: Call(
                 Call {
                     function_type: Some(
                         Function(
-                            Function {
-                                arguments: [
-                                    Reference(
-                                        Reference {
-                                            name: "mapContext",
-                                            position: Position {
-                                                path: "",
-                                                line_number: 1,
-                                                column_number: 1,
-                                                line: "",
+                            Function(
+                                FunctionInner {
+                                    arguments: [
+                                        Reference(
+                                            Reference(
+                                                ReferenceInner {
+                                                    name: "mapContext",
+                                                    position: Position(
+                                                        PositionInner {
+                                                            path: "",
+                                                            line_number: 1,
+                                                            column_number: 1,
+                                                            line: "",
+                                                        },
+                                                    ),
+                                                },
+                                            ),
+                                        ),
+                                        Reference(
+                                            Reference(
+                                                ReferenceInner {
+                                                    name: "genericMap",
+                                                    position: Position(
+                                                        PositionInner {
+                                                            path: "",
+                                                            line_number: 1,
+                                                            column_number: 1,
+                                                            line: "",
+                                                        },
+                                                    ),
+                                                },
+                                            ),
+                                        ),
+                                        Any(
+                                            Any {
+                                                position: Position(
+                                                    PositionInner {
+                                                        path: "",
+                                                        line_number: 1,
+                                                        column_number: 1,
+                                                        line: "",
+                                                    },
+                                                ),
                                             },
-                                        },
-                                    ),
-                                    Reference(
-                                        Reference {
-                                            name: "genericMap",
-                                            position: Position {
-                                                path: "",
-                                                line_number: 1,
-                                                column_number: 1,
-                                                line: "",
+                                        ),
+                                        Any(
+                                            Any {
+                                                position: Position(
+                                                    PositionInner {
+                                                        path: "",
+                                                        line_number: 1,
+                                                        column_number: 1,
+                                                        line: "",
+                                                    },
+                                                ),
                                             },
-                                        },
-                                    ),
-                                    Any(
-                                        Any {
-                                            position: Position {
-                                                path: "",
-                                                line_number: 1,
-                                                column_number: 1,
-                                                line: "",
+                                        ),
+                                    ],
+                                    result: Reference(
+                                        Reference(
+                                            ReferenceInner {
+                                                name: "genericMap",
+                                                position: Position(
+                                                    PositionInner {
+                                                        path: "",
+                                                        line_number: 1,
+                                                        column_number: 1,
+                                                        line: "",
+                                                    },
+                                                ),
                                             },
-                                        },
+                                        ),
                                     ),
-                                    Any(
-                                        Any {
-                                            position: Position {
-                                                path: "",
-                                                line_number: 1,
-                                                column_number: 1,
-                                                line: "",
-                                            },
-                                        },
-                                    ),
-                                ],
-                                result: Reference(
-                                    Reference {
-                                        name: "genericMap",
-                                        position: Position {
+                                    position: Position(
+                                        PositionInner {
                                             path: "",
                                             line_number: 1,
                                             column_number: 1,
                                             line: "",
                                         },
-                                    },
-                                ),
-                                position: Position {
-                                    path: "",
-                                    line_number: 1,
-                                    column_number: 1,
-                                    line: "",
+                                    ),
                                 },
-                            },
+                            ),
                         ),
                     ),
                     function: Variable(
                         Variable {
                             name: "setMap",
-                            position: Position {
-                                path: "",
-                                line_number: 1,
-                                column_number: 1,
-                                line: "",
-                            },
+                            position: Position(
+                                PositionInner {
+                                    path: "",
+                                    line_number: 1,
+                                    column_number: 1,
+                                    line: "",
+                                },
+                            ),
                         },
                     ),
                     arguments: [
                         Variable(
                             Variable {
                                 name: "$ctx",
-                                position: Position {
-                                    path: "",
-                                    line_number: 1,
-                                    column_number: 1,
-                                    line: "",
-                                },
+                                position: Position(
+                                    PositionInner {
+                                        path: "",
+                                        line_number: 1,
+                                        column_number: 1,
+                                        line: "",
+                                    },
+                                ),
                             },
                         ),
                         Call(
                             Call {
                                 function_type: Some(
                                     Function(
-                                        Function {
-                                            arguments: [
-                                                Reference(
-                                                    Reference {
-                                                        name: "mapContext",
-                                                        position: Position {
-                                                            path: "",
-                                                            line_number: 1,
-                                                            column_number: 1,
-                                                            line: "",
+                                        Function(
+                                            FunctionInner {
+                                                arguments: [
+                                                    Reference(
+                                                        Reference(
+                                                            ReferenceInner {
+                                                                name: "mapContext",
+                                                                position: Position(
+                                                                    PositionInner {
+                                                                        path: "",
+                                                                        line_number: 1,
+                                                                        column_number: 1,
+                                                                        line: "",
+                                                                    },
+                                                                ),
+                                                            },
+                                                        ),
+                                                    ),
+                                                    Reference(
+                                                        Reference(
+                                                            ReferenceInner {
+                                                                name: "genericMap",
+                                                                position: Position(
+                                                                    PositionInner {
+                                                                        path: "",
+                                                                        line_number: 1,
+                                                                        column_number: 1,
+                                                                        line: "",
+                                                                    },
+                                                                ),
+                                                            },
+                                                        ),
+                                                    ),
+                                                    Any(
+                                                        Any {
+                                                            position: Position(
+                                                                PositionInner {
+                                                                    path: "",
+                                                                    line_number: 1,
+                                                                    column_number: 1,
+                                                                    line: "",
+                                                                },
+                                                            ),
                                                         },
-                                                    },
-                                                ),
-                                                Reference(
-                                                    Reference {
-                                                        name: "genericMap",
-                                                        position: Position {
-                                                            path: "",
-                                                            line_number: 1,
-                                                            column_number: 1,
-                                                            line: "",
+                                                    ),
+                                                    Any(
+                                                        Any {
+                                                            position: Position(
+                                                                PositionInner {
+                                                                    path: "",
+                                                                    line_number: 1,
+                                                                    column_number: 1,
+                                                                    line: "",
+                                                                },
+                                                            ),
                                                         },
-                                                    },
-                                                ),
-                                                Any(
-                                                    Any {
-                                                        position: Position {
-                                                            path: "",
-                                                            line_number: 1,
-                                                            column_number: 1,
-                                                            line: "",
+                                                    ),
+                                                ],
+                                                result: Reference(
+                                                    Reference(
+                                                        ReferenceInner {
+                                                            name: "genericMap",
+                                                            position: Position(
+                                                                PositionInner {
+                                                                    path: "",
+                                                                    line_number: 1,
+                                                                    column_number: 1,
+                                                                    line: "",
+                                                                },
+                                                            ),
                                                         },
-                                                    },
+                                                    ),
                                                 ),
-                                                Any(
-                                                    Any {
-                                                        position: Position {
-                                                            path: "",
-                                                            line_number: 1,
-                                                            column_number: 1,
-                                                            line: "",
-                                                        },
-                                                    },
-                                                ),
-                                            ],
-                                            result: Reference(
-                                                Reference {
-                                                    name: "genericMap",
-                                                    position: Position {
+                                                position: Position(
+                                                    PositionInner {
                                                         path: "",
                                                         line_number: 1,
                                                         column_number: 1,
                                                         line: "",
                                                     },
-                                                },
-                                            ),
-                                            position: Position {
-                                                path: "",
-                                                line_number: 1,
-                                                column_number: 1,
-                                                line: "",
+                                                ),
                                             },
-                                        },
+                                        ),
                                     ),
                                 ),
                                 function: Variable(
                                     Variable {
                                         name: "setMap",
-                                        position: Position {
-                                            path: "",
-                                            line_number: 1,
-                                            column_number: 1,
-                                            line: "",
-                                        },
+                                        position: Position(
+                                            PositionInner {
+                                                path: "",
+                                                line_number: 1,
+                                                column_number: 1,
+                                                line: "",
+                                            },
+                                        ),
                                     },
                                 ),
                                 arguments: [
                                     Variable(
                                         Variable {
                                             name: "$ctx",
-                                            position: Position {
-                                                path: "",
-                                                line_number: 1,
-                                                column_number: 1,
-                                                line: "",
-                                            },
+                                            position: Position(
+                                                PositionInner {
+                                                    path: "",
+                                                    line_number: 1,
+                                                    column_number: 1,
+                                                    line: "",
+                                                },
+                                            ),
                                         },
                                     ),
                                     Call(
                                         Call {
                                             function_type: Some(
                                                 Function(
-                                                    Function {
-                                                        arguments: [],
-                                                        result: Reference(
-                                                            Reference {
-                                                                name: "genericMap",
-                                                                position: Position {
+                                                    Function(
+                                                        FunctionInner {
+                                                            arguments: [],
+                                                            result: Reference(
+                                                                Reference(
+                                                                    ReferenceInner {
+                                                                        name: "genericMap",
+                                                                        position: Position(
+                                                                            PositionInner {
+                                                                                path: "",
+                                                                                line_number: 1,
+                                                                                column_number: 1,
+                                                                                line: "",
+                                                                            },
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                            ),
+                                                            position: Position(
+                                                                PositionInner {
                                                                     path: "",
                                                                     line_number: 1,
                                                                     column_number: 1,
                                                                     line: "",
                                                                 },
-                                                            },
-                                                        ),
-                                                        position: Position {
-                                                            path: "",
-                                                            line_number: 1,
-                                                            column_number: 1,
-                                                            line: "",
+                                                            ),
                                                         },
-                                                    },
+                                                    ),
                                                 ),
                                             ),
                                             function: Variable(
                                                 Variable {
                                                     name: "emptyMap",
-                                                    position: Position {
-                                                        path: "",
-                                                        line_number: 1,
-                                                        column_number: 1,
-                                                        line: "",
-                                                    },
+                                                    position: Position(
+                                                        PositionInner {
+                                                            path: "",
+                                                            line_number: 1,
+                                                            column_number: 1,
+                                                            line: "",
+                                                        },
+                                                    ),
                                                 },
                                             ),
                                             arguments: [],
-                                            position: Position {
-                                                path: "",
-                                                line_number: 1,
-                                                column_number: 1,
-                                                line: "",
-                                            },
+                                            position: Position(
+                                                PositionInner {
+                                                    path: "",
+                                                    line_number: 1,
+                                                    column_number: 1,
+                                                    line: "",
+                                                },
+                                            ),
                                         },
                                     ),
                                     TypeCoercion(
                                         TypeCoercion {
                                             from: None(
                                                 None {
-                                                    position: Position {
-                                                        path: "",
-                                                        line_number: 1,
-                                                        column_number: 1,
-                                                        line: "",
-                                                    },
+                                                    position: Position(
+                                                        PositionInner {
+                                                            path: "",
+                                                            line_number: 1,
+                                                            column_number: 1,
+                                                            line: "",
+                                                        },
+                                                    ),
                                                 },
                                             ),
                                             to: Any(
                                                 Any {
-                                                    position: Position {
-                                                        path: "",
-                                                        line_number: 1,
-                                                        column_number: 1,
-                                                        line: "",
-                                                    },
+                                                    position: Position(
+                                                        PositionInner {
+                                                            path: "",
+                                                            line_number: 1,
+                                                            column_number: 1,
+                                                            line: "",
+                                                        },
+                                                    ),
                                                 },
                                             ),
                                             argument: Number(
                                                 Number {
                                                     value: 1.0,
-                                                    position: Position {
-                                                        path: "",
-                                                        line_number: 1,
-                                                        column_number: 1,
-                                                        line: "",
-                                                    },
+                                                    position: Position(
+                                                        PositionInner {
+                                                            path: "",
+                                                            line_number: 1,
+                                                            column_number: 1,
+                                                            line: "",
+                                                        },
+                                                    ),
                                                 },
                                             ),
-                                            position: Position {
-                                                path: "",
-                                                line_number: 1,
-                                                column_number: 1,
-                                                line: "",
-                                            },
+                                            position: Position(
+                                                PositionInner {
+                                                    path: "",
+                                                    line_number: 1,
+                                                    column_number: 1,
+                                                    line: "",
+                                                },
+                                            ),
                                         },
                                     ),
                                     TypeCoercion(
                                         TypeCoercion {
                                             from: None(
                                                 None {
-                                                    position: Position {
-                                                        path: "",
-                                                        line_number: 1,
-                                                        column_number: 1,
-                                                        line: "",
-                                                    },
+                                                    position: Position(
+                                                        PositionInner {
+                                                            path: "",
+                                                            line_number: 1,
+                                                            column_number: 1,
+                                                            line: "",
+                                                        },
+                                                    ),
                                                 },
                                             ),
                                             to: Any(
                                                 Any {
-                                                    position: Position {
-                                                        path: "",
-                                                        line_number: 1,
-                                                        column_number: 1,
-                                                        line: "",
-                                                    },
+                                                    position: Position(
+                                                        PositionInner {
+                                                            path: "",
+                                                            line_number: 1,
+                                                            column_number: 1,
+                                                            line: "",
+                                                        },
+                                                    ),
                                                 },
                                             ),
                                             argument: None(
                                                 None {
-                                                    position: Position {
-                                                        path: "",
-                                                        line_number: 1,
-                                                        column_number: 1,
-                                                        line: "",
-                                                    },
+                                                    position: Position(
+                                                        PositionInner {
+                                                            path: "",
+                                                            line_number: 1,
+                                                            column_number: 1,
+                                                            line: "",
+                                                        },
+                                                    ),
                                                 },
                                             ),
-                                            position: Position {
+                                            position: Position(
+                                                PositionInner {
+                                                    path: "",
+                                                    line_number: 1,
+                                                    column_number: 1,
+                                                    line: "",
+                                                },
+                                            ),
+                                        },
+                                    ),
+                                ],
+                                position: Position(
+                                    PositionInner {
+                                        path: "",
+                                        line_number: 1,
+                                        column_number: 1,
+                                        line: "",
+                                    },
+                                ),
+                            },
+                        ),
+                        TypeCoercion(
+                            TypeCoercion {
+                                from: None(
+                                    None {
+                                        position: Position(
+                                            PositionInner {
                                                 path: "",
                                                 line_number: 1,
                                                 column_number: 1,
                                                 line: "",
                                             },
-                                        },
-                                    ),
-                                ],
-                                position: Position {
-                                    path: "",
-                                    line_number: 1,
-                                    column_number: 1,
-                                    line: "",
-                                },
-                            },
-                        ),
-                        TypeCoercion(
-                            TypeCoercion {
-                                from: None(
-                                    None {
-                                        position: Position {
-                                            path: "",
-                                            line_number: 1,
-                                            column_number: 1,
-                                            line: "",
-                                        },
+                                        ),
                                     },
                                 ),
                                 to: Any(
                                     Any {
-                                        position: Position {
-                                            path: "",
-                                            line_number: 1,
-                                            column_number: 1,
-                                            line: "",
-                                        },
+                                        position: Position(
+                                            PositionInner {
+                                                path: "",
+                                                line_number: 1,
+                                                column_number: 1,
+                                                line: "",
+                                            },
+                                        ),
                                     },
                                 ),
                                 argument: Number(
                                     Number {
                                         value: 2.0,
-                                        position: Position {
-                                            path: "",
-                                            line_number: 1,
-                                            column_number: 1,
-                                            line: "",
-                                        },
+                                        position: Position(
+                                            PositionInner {
+                                                path: "",
+                                                line_number: 1,
+                                                column_number: 1,
+                                                line: "",
+                                            },
+                                        ),
                                     },
                                 ),
-                                position: Position {
-                                    path: "",
-                                    line_number: 1,
-                                    column_number: 1,
-                                    line: "",
-                                },
+                                position: Position(
+                                    PositionInner {
+                                        path: "",
+                                        line_number: 1,
+                                        column_number: 1,
+                                        line: "",
+                                    },
+                                ),
                             },
                         ),
                         TypeCoercion(
                             TypeCoercion {
                                 from: None(
                                     None {
-                                        position: Position {
-                                            path: "",
-                                            line_number: 1,
-                                            column_number: 1,
-                                            line: "",
-                                        },
+                                        position: Position(
+                                            PositionInner {
+                                                path: "",
+                                                line_number: 1,
+                                                column_number: 1,
+                                                line: "",
+                                            },
+                                        ),
                                     },
                                 ),
                                 to: Any(
                                     Any {
-                                        position: Position {
-                                            path: "",
-                                            line_number: 1,
-                                            column_number: 1,
-                                            line: "",
-                                        },
+                                        position: Position(
+                                            PositionInner {
+                                                path: "",
+                                                line_number: 1,
+                                                column_number: 1,
+                                                line: "",
+                                            },
+                                        ),
                                     },
                                 ),
                                 argument: None(
                                     None {
-                                        position: Position {
-                                            path: "",
-                                            line_number: 1,
-                                            column_number: 1,
-                                            line: "",
-                                        },
+                                        position: Position(
+                                            PositionInner {
+                                                path: "",
+                                                line_number: 1,
+                                                column_number: 1,
+                                                line: "",
+                                            },
+                                        ),
                                     },
                                 ),
-                                position: Position {
-                                    path: "",
-                                    line_number: 1,
-                                    column_number: 1,
-                                    line: "",
-                                },
+                                position: Position(
+                                    PositionInner {
+                                        path: "",
+                                        line_number: 1,
+                                        column_number: 1,
+                                        line: "",
+                                    },
+                                ),
                             },
                         ),
                     ],
-                    position: Position {
-                        path: "",
-                        line_number: 1,
-                        column_number: 1,
-                        line: "",
-                    },
+                    position: Position(
+                        PositionInner {
+                            path: "",
+                            line_number: 1,
+                            column_number: 1,
+                            line: "",
+                        },
+                    ),
                 },
             ),
-            position: Position {
-                path: "",
-                line_number: 1,
-                column_number: 1,
-                line: "",
-            },
+            position: Position(
+                PositionInner {
+                    path: "",
+                    line_number: 1,
+                    column_number: 1,
+                    line: "",
+                },
+            ),
         },
     ),
 )

--- a/lib/hir-mir/src/transformation/snapshots/hir_mir__transformation__map_literal__tests__transform_map_with_entry.snap
+++ b/lib/hir-mir/src/transformation/snapshots/hir_mir__transformation__map_literal__tests__transform_map_with_entry.snap
@@ -10,296 +10,368 @@ Ok(
             ),
             type_: Some(
                 Reference(
-                    Reference {
-                        name: "mapContext",
-                        position: Position {
-                            path: "",
-                            line_number: 1,
-                            column_number: 1,
-                            line: "",
+                    Reference(
+                        ReferenceInner {
+                            name: "mapContext",
+                            position: Position(
+                                PositionInner {
+                                    path: "",
+                                    line_number: 1,
+                                    column_number: 1,
+                                    line: "",
+                                },
+                            ),
                         },
-                    },
+                    ),
                 ),
             ),
             bound_expression: Call(
                 Call {
                     function_type: Some(
                         Function(
-                            Function {
-                                arguments: [],
-                                result: Reference(
-                                    Reference {
-                                        name: "mapContext",
-                                        position: Position {
+                            Function(
+                                FunctionInner {
+                                    arguments: [],
+                                    result: Reference(
+                                        Reference(
+                                            ReferenceInner {
+                                                name: "mapContext",
+                                                position: Position(
+                                                    PositionInner {
+                                                        path: "",
+                                                        line_number: 1,
+                                                        column_number: 1,
+                                                        line: "",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                    position: Position(
+                                        PositionInner {
                                             path: "",
                                             line_number: 1,
                                             column_number: 1,
                                             line: "",
                                         },
-                                    },
-                                ),
-                                position: Position {
-                                    path: "",
-                                    line_number: 1,
-                                    column_number: 1,
-                                    line: "",
+                                    ),
                                 },
-                            },
+                            ),
                         ),
                     ),
                     function: Variable(
                         Variable {
                             name: "hir:map:context:829f738c8f9ee2f4",
-                            position: Position {
-                                path: "",
-                                line_number: 1,
-                                column_number: 1,
-                                line: "",
-                            },
+                            position: Position(
+                                PositionInner {
+                                    path: "",
+                                    line_number: 1,
+                                    column_number: 1,
+                                    line: "",
+                                },
+                            ),
                         },
                     ),
                     arguments: [],
-                    position: Position {
-                        path: "",
-                        line_number: 1,
-                        column_number: 1,
-                        line: "",
-                    },
+                    position: Position(
+                        PositionInner {
+                            path: "",
+                            line_number: 1,
+                            column_number: 1,
+                            line: "",
+                        },
+                    ),
                 },
             ),
             expression: Call(
                 Call {
                     function_type: Some(
                         Function(
-                            Function {
-                                arguments: [
-                                    Reference(
-                                        Reference {
-                                            name: "mapContext",
-                                            position: Position {
-                                                path: "",
-                                                line_number: 1,
-                                                column_number: 1,
-                                                line: "",
+                            Function(
+                                FunctionInner {
+                                    arguments: [
+                                        Reference(
+                                            Reference(
+                                                ReferenceInner {
+                                                    name: "mapContext",
+                                                    position: Position(
+                                                        PositionInner {
+                                                            path: "",
+                                                            line_number: 1,
+                                                            column_number: 1,
+                                                            line: "",
+                                                        },
+                                                    ),
+                                                },
+                                            ),
+                                        ),
+                                        Reference(
+                                            Reference(
+                                                ReferenceInner {
+                                                    name: "genericMap",
+                                                    position: Position(
+                                                        PositionInner {
+                                                            path: "",
+                                                            line_number: 1,
+                                                            column_number: 1,
+                                                            line: "",
+                                                        },
+                                                    ),
+                                                },
+                                            ),
+                                        ),
+                                        Any(
+                                            Any {
+                                                position: Position(
+                                                    PositionInner {
+                                                        path: "",
+                                                        line_number: 1,
+                                                        column_number: 1,
+                                                        line: "",
+                                                    },
+                                                ),
                                             },
-                                        },
-                                    ),
-                                    Reference(
-                                        Reference {
-                                            name: "genericMap",
-                                            position: Position {
-                                                path: "",
-                                                line_number: 1,
-                                                column_number: 1,
-                                                line: "",
+                                        ),
+                                        Any(
+                                            Any {
+                                                position: Position(
+                                                    PositionInner {
+                                                        path: "",
+                                                        line_number: 1,
+                                                        column_number: 1,
+                                                        line: "",
+                                                    },
+                                                ),
                                             },
-                                        },
-                                    ),
-                                    Any(
-                                        Any {
-                                            position: Position {
-                                                path: "",
-                                                line_number: 1,
-                                                column_number: 1,
-                                                line: "",
+                                        ),
+                                    ],
+                                    result: Reference(
+                                        Reference(
+                                            ReferenceInner {
+                                                name: "genericMap",
+                                                position: Position(
+                                                    PositionInner {
+                                                        path: "",
+                                                        line_number: 1,
+                                                        column_number: 1,
+                                                        line: "",
+                                                    },
+                                                ),
                                             },
-                                        },
+                                        ),
                                     ),
-                                    Any(
-                                        Any {
-                                            position: Position {
-                                                path: "",
-                                                line_number: 1,
-                                                column_number: 1,
-                                                line: "",
-                                            },
-                                        },
-                                    ),
-                                ],
-                                result: Reference(
-                                    Reference {
-                                        name: "genericMap",
-                                        position: Position {
+                                    position: Position(
+                                        PositionInner {
                                             path: "",
                                             line_number: 1,
                                             column_number: 1,
                                             line: "",
                                         },
-                                    },
-                                ),
-                                position: Position {
-                                    path: "",
-                                    line_number: 1,
-                                    column_number: 1,
-                                    line: "",
+                                    ),
                                 },
-                            },
+                            ),
                         ),
                     ),
                     function: Variable(
                         Variable {
                             name: "setMap",
-                            position: Position {
-                                path: "",
-                                line_number: 1,
-                                column_number: 1,
-                                line: "",
-                            },
+                            position: Position(
+                                PositionInner {
+                                    path: "",
+                                    line_number: 1,
+                                    column_number: 1,
+                                    line: "",
+                                },
+                            ),
                         },
                     ),
                     arguments: [
                         Variable(
                             Variable {
                                 name: "$ctx",
-                                position: Position {
-                                    path: "",
-                                    line_number: 1,
-                                    column_number: 1,
-                                    line: "",
-                                },
+                                position: Position(
+                                    PositionInner {
+                                        path: "",
+                                        line_number: 1,
+                                        column_number: 1,
+                                        line: "",
+                                    },
+                                ),
                             },
                         ),
                         Call(
                             Call {
                                 function_type: Some(
                                     Function(
-                                        Function {
-                                            arguments: [],
-                                            result: Reference(
-                                                Reference {
-                                                    name: "genericMap",
-                                                    position: Position {
+                                        Function(
+                                            FunctionInner {
+                                                arguments: [],
+                                                result: Reference(
+                                                    Reference(
+                                                        ReferenceInner {
+                                                            name: "genericMap",
+                                                            position: Position(
+                                                                PositionInner {
+                                                                    path: "",
+                                                                    line_number: 1,
+                                                                    column_number: 1,
+                                                                    line: "",
+                                                                },
+                                                            ),
+                                                        },
+                                                    ),
+                                                ),
+                                                position: Position(
+                                                    PositionInner {
                                                         path: "",
                                                         line_number: 1,
                                                         column_number: 1,
                                                         line: "",
                                                     },
-                                                },
-                                            ),
-                                            position: Position {
-                                                path: "",
-                                                line_number: 1,
-                                                column_number: 1,
-                                                line: "",
+                                                ),
                                             },
-                                        },
+                                        ),
                                     ),
                                 ),
                                 function: Variable(
                                     Variable {
                                         name: "emptyMap",
-                                        position: Position {
-                                            path: "",
-                                            line_number: 1,
-                                            column_number: 1,
-                                            line: "",
-                                        },
+                                        position: Position(
+                                            PositionInner {
+                                                path: "",
+                                                line_number: 1,
+                                                column_number: 1,
+                                                line: "",
+                                            },
+                                        ),
                                     },
                                 ),
                                 arguments: [],
-                                position: Position {
-                                    path: "",
-                                    line_number: 1,
-                                    column_number: 1,
-                                    line: "",
-                                },
+                                position: Position(
+                                    PositionInner {
+                                        path: "",
+                                        line_number: 1,
+                                        column_number: 1,
+                                        line: "",
+                                    },
+                                ),
                             },
                         ),
                         TypeCoercion(
                             TypeCoercion {
                                 from: None(
                                     None {
-                                        position: Position {
-                                            path: "",
-                                            line_number: 1,
-                                            column_number: 1,
-                                            line: "",
-                                        },
+                                        position: Position(
+                                            PositionInner {
+                                                path: "",
+                                                line_number: 1,
+                                                column_number: 1,
+                                                line: "",
+                                            },
+                                        ),
                                     },
                                 ),
                                 to: Any(
                                     Any {
-                                        position: Position {
-                                            path: "",
-                                            line_number: 1,
-                                            column_number: 1,
-                                            line: "",
-                                        },
+                                        position: Position(
+                                            PositionInner {
+                                                path: "",
+                                                line_number: 1,
+                                                column_number: 1,
+                                                line: "",
+                                            },
+                                        ),
                                     },
                                 ),
                                 argument: None(
                                     None {
-                                        position: Position {
-                                            path: "",
-                                            line_number: 1,
-                                            column_number: 1,
-                                            line: "",
-                                        },
+                                        position: Position(
+                                            PositionInner {
+                                                path: "",
+                                                line_number: 1,
+                                                column_number: 1,
+                                                line: "",
+                                            },
+                                        ),
                                     },
                                 ),
-                                position: Position {
-                                    path: "",
-                                    line_number: 1,
-                                    column_number: 1,
-                                    line: "",
-                                },
+                                position: Position(
+                                    PositionInner {
+                                        path: "",
+                                        line_number: 1,
+                                        column_number: 1,
+                                        line: "",
+                                    },
+                                ),
                             },
                         ),
                         TypeCoercion(
                             TypeCoercion {
                                 from: None(
                                     None {
-                                        position: Position {
-                                            path: "",
-                                            line_number: 1,
-                                            column_number: 1,
-                                            line: "",
-                                        },
+                                        position: Position(
+                                            PositionInner {
+                                                path: "",
+                                                line_number: 1,
+                                                column_number: 1,
+                                                line: "",
+                                            },
+                                        ),
                                     },
                                 ),
                                 to: Any(
                                     Any {
-                                        position: Position {
-                                            path: "",
-                                            line_number: 1,
-                                            column_number: 1,
-                                            line: "",
-                                        },
+                                        position: Position(
+                                            PositionInner {
+                                                path: "",
+                                                line_number: 1,
+                                                column_number: 1,
+                                                line: "",
+                                            },
+                                        ),
                                     },
                                 ),
                                 argument: None(
                                     None {
-                                        position: Position {
-                                            path: "",
-                                            line_number: 1,
-                                            column_number: 1,
-                                            line: "",
-                                        },
+                                        position: Position(
+                                            PositionInner {
+                                                path: "",
+                                                line_number: 1,
+                                                column_number: 1,
+                                                line: "",
+                                            },
+                                        ),
                                     },
                                 ),
-                                position: Position {
-                                    path: "",
-                                    line_number: 1,
-                                    column_number: 1,
-                                    line: "",
-                                },
+                                position: Position(
+                                    PositionInner {
+                                        path: "",
+                                        line_number: 1,
+                                        column_number: 1,
+                                        line: "",
+                                    },
+                                ),
                             },
                         ),
                     ],
-                    position: Position {
-                        path: "",
-                        line_number: 1,
-                        column_number: 1,
-                        line: "",
-                    },
+                    position: Position(
+                        PositionInner {
+                            path: "",
+                            line_number: 1,
+                            column_number: 1,
+                            line: "",
+                        },
+                    ),
                 },
             ),
-            position: Position {
-                path: "",
-                line_number: 1,
-                column_number: 1,
-                line: "",
-            },
+            position: Position(
+                PositionInner {
+                    path: "",
+                    line_number: 1,
+                    column_number: 1,
+                    line: "",
+                },
+            ),
         },
     ),
 )

--- a/lib/hir-mir/src/transformation/snapshots/hir_mir__transformation__map_literal__tests__transform_map_with_spread_map.snap
+++ b/lib/hir-mir/src/transformation/snapshots/hir_mir__transformation__map_literal__tests__transform_map_with_spread_map.snap
@@ -1,6 +1,6 @@
 ---
 source: lib/hir-mir/src/transformation/map_literal.rs
-expression: "transform(&CompileContext::dummy(Default::default(), Default::default()),\n    &Map::new(types::None::new(Position::fake()),\n            types::None::new(Position::fake()),\n            vec![MapElement :: Map(None :: new(Position :: fake()).into())],\n            Position::fake()))"
+expression: "transform(&Context::dummy(Default::default(), Default::default()),\n    &Map::new(types::None::new(Position::fake()),\n            types::None::new(Position::fake()),\n            vec![MapElement :: Map(None :: new(Position :: fake()).into())],\n            Position::fake()))"
 ---
 Ok(
     Let(
@@ -10,79 +10,99 @@ Ok(
             ),
             type_: Some(
                 Reference(
-                    Reference {
-                        name: "mapContext",
-                        position: Position {
-                            path: "",
-                            line_number: 1,
-                            column_number: 1,
-                            line: "",
+                    Reference(
+                        ReferenceInner {
+                            name: "mapContext",
+                            position: Position(
+                                PositionInner {
+                                    path: "",
+                                    line_number: 1,
+                                    column_number: 1,
+                                    line: "",
+                                },
+                            ),
                         },
-                    },
+                    ),
                 ),
             ),
             bound_expression: Call(
                 Call {
                     function_type: Some(
                         Function(
-                            Function {
-                                arguments: [],
-                                result: Reference(
-                                    Reference {
-                                        name: "mapContext",
-                                        position: Position {
+                            Function(
+                                FunctionInner {
+                                    arguments: [],
+                                    result: Reference(
+                                        Reference(
+                                            ReferenceInner {
+                                                name: "mapContext",
+                                                position: Position(
+                                                    PositionInner {
+                                                        path: "",
+                                                        line_number: 1,
+                                                        column_number: 1,
+                                                        line: "",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                    position: Position(
+                                        PositionInner {
                                             path: "",
                                             line_number: 1,
                                             column_number: 1,
                                             line: "",
                                         },
-                                    },
-                                ),
-                                position: Position {
-                                    path: "",
-                                    line_number: 1,
-                                    column_number: 1,
-                                    line: "",
+                                    ),
                                 },
-                            },
+                            ),
                         ),
                     ),
                     function: Variable(
                         Variable {
                             name: "hir:map:context:829f738c8f9ee2f4",
-                            position: Position {
-                                path: "",
-                                line_number: 1,
-                                column_number: 1,
-                                line: "",
-                            },
+                            position: Position(
+                                PositionInner {
+                                    path: "",
+                                    line_number: 1,
+                                    column_number: 1,
+                                    line: "",
+                                },
+                            ),
                         },
                     ),
                     arguments: [],
-                    position: Position {
-                        path: "",
-                        line_number: 1,
-                        column_number: 1,
-                        line: "",
-                    },
+                    position: Position(
+                        PositionInner {
+                            path: "",
+                            line_number: 1,
+                            column_number: 1,
+                            line: "",
+                        },
+                    ),
                 },
             ),
             expression: None(
                 None {
-                    position: Position {
-                        path: "",
-                        line_number: 1,
-                        column_number: 1,
-                        line: "",
-                    },
+                    position: Position(
+                        PositionInner {
+                            path: "",
+                            line_number: 1,
+                            column_number: 1,
+                            line: "",
+                        },
+                    ),
                 },
             ),
-            position: Position {
-                path: "",
-                line_number: 1,
-                column_number: 1,
-                line: "",
-            },
+            position: Position(
+                PositionInner {
+                    path: "",
+                    line_number: 1,
+                    column_number: 1,
+                    line: "",
+                },
+            ),
         },
     ),
 )

--- a/lib/hir/src/types/function.rs
+++ b/lib/hir/src/types/function.rs
@@ -4,35 +4,47 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub struct Function {
-    arguments: Vec<Type>,
+pub struct Function(Arc<FunctionInner>);
+
+#[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+struct FunctionInner {
+    arguments: Arc<[Type]>,
     result: Arc<Type>,
     position: Position,
 }
 
 impl Function {
     pub fn new(arguments: Vec<Type>, result: impl Into<Type>, position: Position) -> Self {
-        Self {
-            arguments,
-            result: Arc::new(result.into()),
-            position,
-        }
+        Self(
+            FunctionInner {
+                arguments: arguments.into(),
+                result: Arc::new(result.into()),
+                position,
+            }
+            .into(),
+        )
     }
 
     pub fn arguments(&self) -> &[Type] {
-        &self.arguments
+        &self.0.arguments
     }
 
     pub fn result(&self) -> &Type {
-        &self.result
+        &self.0.result
     }
 
     pub fn position(&self) -> &Position {
-        &self.position
+        &self.0.position
     }
 
-    pub fn set_position(mut self, position: Position) -> Self {
-        self.position = position;
-        self
+    pub fn set_position(self, position: Position) -> Self {
+        Self(
+            FunctionInner {
+                arguments: self.0.arguments.clone(),
+                result: self.0.result.clone(),
+                position,
+            }
+            .into(),
+        )
     }
 }

--- a/lib/hir/src/types/function.rs
+++ b/lib/hir/src/types/function.rs
@@ -9,7 +9,7 @@ pub struct Function(Arc<FunctionInner>);
 #[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 struct FunctionInner {
     arguments: Arc<[Type]>,
-    result: Arc<Type>,
+    result: Type,
     position: Position,
 }
 
@@ -18,7 +18,7 @@ impl Function {
         Self(
             FunctionInner {
                 arguments: arguments.into(),
-                result: Arc::new(result.into()),
+                result: result.into(),
                 position,
             }
             .into(),

--- a/lib/hir/src/types/list.rs
+++ b/lib/hir/src/types/list.rs
@@ -4,29 +4,40 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub struct List {
-    element: Arc<Type>,
+pub struct List(Arc<ListInner>);
+
+#[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+struct ListInner {
+    element: Type,
     position: Position,
 }
 
 impl List {
     pub fn new(element: impl Into<Type>, position: Position) -> Self {
-        Self {
-            element: Arc::new(element.into()),
-            position,
-        }
+        Self(
+            ListInner {
+                element: element.into(),
+                position,
+            }
+            .into(),
+        )
     }
 
     pub fn element(&self) -> &Type {
-        &self.element
+        &self.0.element
     }
 
     pub fn position(&self) -> &Position {
-        &self.position
+        &self.0.position
     }
 
-    pub fn set_position(mut self, position: Position) -> Self {
-        self.position = position;
-        self
+    pub fn set_position(&self, position: Position) -> Self {
+        Self(
+            ListInner {
+                element: self.0.element.clone(),
+                position,
+            }
+            .into(),
+        )
     }
 }

--- a/lib/hir/src/types/map.rs
+++ b/lib/hir/src/types/map.rs
@@ -4,35 +4,47 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub struct Map {
-    key: Arc<Type>,
-    value: Arc<Type>,
+pub struct Map(Arc<MapInner>);
+
+#[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+struct MapInner {
+    key: Type,
+    value: Type,
     position: Position,
 }
 
 impl Map {
     pub fn new(key: impl Into<Type>, value: impl Into<Type>, position: Position) -> Self {
-        Self {
-            key: Arc::new(key.into()),
-            value: Arc::new(value.into()),
-            position,
-        }
+        Self(
+            MapInner {
+                key: (key.into()),
+                value: (value.into()),
+                position,
+            }
+            .into(),
+        )
     }
 
     pub fn key(&self) -> &Type {
-        &self.key
+        &self.0.key
     }
 
     pub fn value(&self) -> &Type {
-        &self.value
+        &self.0.value
     }
 
     pub fn position(&self) -> &Position {
-        &self.position
+        &self.0.position
     }
 
-    pub fn set_position(mut self, position: Position) -> Self {
-        self.position = position;
-        self
+    pub fn set_position(&self, position: Position) -> Self {
+        Self(
+            MapInner {
+                key: (self.0.key.clone()),
+                value: (self.0.value.clone()),
+                position,
+            }
+            .into(),
+        )
     }
 }

--- a/lib/hir/src/types/record.rs
+++ b/lib/hir/src/types/record.rs
@@ -1,8 +1,12 @@
 use position::Position;
 use serde::{Deserialize, Serialize};
+use std::sync::Arc;
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize)]
-pub struct Record {
+pub struct Record(Arc<RecordInner>);
+
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize)]
+struct RecordInner {
     name: String,
     original_name: String,
     position: Position,
@@ -14,27 +18,36 @@ impl Record {
         original_name: impl Into<String>,
         position: Position,
     ) -> Self {
-        Self {
-            name: name.into(),
-            original_name: original_name.into(),
-            position,
-        }
+        Self(
+            RecordInner {
+                name: name.into().into(),
+                original_name: original_name.into().into(),
+                position,
+            }
+            .into(),
+        )
     }
 
     pub fn name(&self) -> &str {
-        &self.name
+        &self.0.name
     }
 
     pub fn original_name(&self) -> &str {
-        &self.original_name
+        &self.0.original_name
     }
 
     pub fn position(&self) -> &Position {
-        &self.position
+        &self.0.position
     }
 
-    pub fn set_position(mut self, position: Position) -> Self {
-        self.position = position;
-        self
+    pub fn set_position(&self, position: Position) -> Self {
+        Self(
+            RecordInner {
+                name: self.0.name.clone(),
+                original_name: self.0.original_name.clone(),
+                position,
+            }
+            .into(),
+        )
     }
 }

--- a/lib/hir/src/types/record.rs
+++ b/lib/hir/src/types/record.rs
@@ -20,8 +20,8 @@ impl Record {
     ) -> Self {
         Self(
             RecordInner {
-                name: name.into().into(),
-                original_name: original_name.into().into(),
+                name: name.into(),
+                original_name: original_name.into(),
                 position,
             }
             .into(),

--- a/lib/hir/src/types/reference.rs
+++ b/lib/hir/src/types/reference.rs
@@ -1,30 +1,42 @@
 use position::Position;
 use serde::{Deserialize, Serialize};
+use std::sync::Arc;
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub struct Reference {
+pub struct Reference(Arc<ReferenceInner>);
+
+#[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+struct ReferenceInner {
     name: String,
     position: Position,
 }
 
 impl Reference {
     pub fn new(name: impl Into<String>, position: Position) -> Self {
-        Self {
-            name: name.into(),
-            position,
-        }
+        Self(
+            ReferenceInner {
+                name: name.into(),
+                position,
+            }
+            .into(),
+        )
     }
 
     pub fn name(&self) -> &str {
-        &self.name
+        &self.0.name
     }
 
     pub fn position(&self) -> &Position {
-        &self.position
+        &self.0.position
     }
 
-    pub fn set_position(mut self, position: Position) -> Self {
-        self.position = position;
-        self
+    pub fn set_position(&self, position: Position) -> Self {
+        Self(
+            ReferenceInner {
+                name: self.0.name.clone(),
+                position,
+            }
+            .into(),
+        )
     }
 }

--- a/lib/hir/src/types/union.rs
+++ b/lib/hir/src/types/union.rs
@@ -17,8 +17,8 @@ impl Union {
     pub fn new(lhs: impl Into<Type>, rhs: impl Into<Type>, position: Position) -> Self {
         Self(
             UnionInner {
-                lhs: lhs.into().into(),
-                rhs: rhs.into().into(),
+                lhs: lhs.into(),
+                rhs: rhs.into(),
                 position,
             }
             .into(),

--- a/lib/hir/src/types/union.rs
+++ b/lib/hir/src/types/union.rs
@@ -37,7 +37,7 @@ impl Union {
         &self.0.position
     }
 
-    pub fn set_position(mut self, position: Position) -> Self {
+    pub fn set_position(&self, position: Position) -> Self {
         Self(
             UnionInner {
                 lhs: self.0.lhs.clone(),

--- a/lib/hir/src/types/union.rs
+++ b/lib/hir/src/types/union.rs
@@ -4,35 +4,47 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub struct Union {
-    lhs: Arc<Type>,
-    rhs: Arc<Type>,
+pub struct Union(Arc<UnionInner>);
+
+#[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+struct UnionInner {
+    lhs: Type,
+    rhs: Type,
     position: Position,
 }
 
 impl Union {
     pub fn new(lhs: impl Into<Type>, rhs: impl Into<Type>, position: Position) -> Self {
-        Self {
-            lhs: lhs.into().into(),
-            rhs: rhs.into().into(),
-            position,
-        }
+        Self(
+            UnionInner {
+                lhs: lhs.into().into(),
+                rhs: rhs.into().into(),
+                position,
+            }
+            .into(),
+        )
     }
 
     pub fn lhs(&self) -> &Type {
-        &self.lhs
+        &self.0.lhs
     }
 
     pub fn rhs(&self) -> &Type {
-        &self.rhs
+        &self.0.rhs
     }
 
     pub fn position(&self) -> &Position {
-        &self.position
+        &self.0.position
     }
 
     pub fn set_position(mut self, position: Position) -> Self {
-        self.position = position;
-        self
+        Self(
+            UnionInner {
+                lhs: self.0.lhs.clone(),
+                rhs: self.0.rhs.clone(),
+                position,
+            }
+            .into(),
+        )
     }
 }

--- a/lib/parse/src/snapshots/parse__parsers__tests__expressions__call__fail_to_parse_call.snap
+++ b/lib/parse/src/snapshots/parse__parsers__tests__expressions__call__fail_to_parse_call.snap
@@ -25,11 +25,13 @@ Some(
             "string literal",
             "variable",
         ],
-        position: Position {
-            path: "",
-            line_number: 1,
-            column_number: 5,
-            line: "f(1+)",
-        },
+        position: Position(
+            PositionInner {
+                path: "",
+                line_number: 1,
+                column_number: 5,
+                line: "f(1+)",
+            },
+        ),
     },
 )

--- a/lib/parse/src/snapshots/parse__parsers__tests__import__fail_to_parse_private_external_module_directory.snap
+++ b/lib/parse/src/snapshots/parse__parsers__tests__import__fail_to_parse_private_external_module_directory.snap
@@ -1,7 +1,6 @@
 ---
 source: lib/parse/src/parsers.rs
-expression: "external_module_path().parse(stream(source,\n                                    \"\")).map_err(|error|\n                                                     ParseError::new(source,\n                                                                     \"\",\n                                                                     error)).err()"
-
+expression: "external_module_path().parse(stream(source,\n                \"\")).map_err(|error| ParseError::new(source, \"\", error)).err()"
 ---
 Some(
     ParseError {
@@ -9,11 +8,13 @@ Some(
         expected: [
             "public module path",
         ],
-        position: Position {
-            path: "",
-            line_number: 1,
-            column_number: 5,
-            line: "Foo'bar'Baz",
-        },
+        position: Position(
+            PositionInner {
+                path: "",
+                line_number: 1,
+                column_number: 5,
+                line: "Foo'bar'Baz",
+            },
+        ),
     },
 )

--- a/lib/parse/src/snapshots/parse__parsers__tests__import__fail_to_parse_private_external_module_file.snap
+++ b/lib/parse/src/snapshots/parse__parsers__tests__import__fail_to_parse_private_external_module_file.snap
@@ -1,7 +1,6 @@
 ---
 source: lib/parse/src/parsers.rs
-expression: "external_module_path().parse(stream(source,\n                                    \"\")).map_err(|error|\n                                                     ParseError::new(source,\n                                                                     \"\",\n                                                                     error)).err()"
-
+expression: "external_module_path().parse(stream(source,\n                \"\")).map_err(|error| ParseError::new(source, \"\", error)).err()"
 ---
 Some(
     ParseError {
@@ -9,11 +8,13 @@ Some(
         expected: [
             "public module path",
         ],
-        position: Position {
-            path: "",
-            line_number: 1,
-            column_number: 5,
-            line: "Foo'bar",
-        },
+        position: Position(
+            PositionInner {
+                path: "",
+                line_number: 1,
+                column_number: 5,
+                line: "Foo'bar",
+            },
+        ),
     },
 )

--- a/lib/position/src/position.rs
+++ b/lib/position/src/position.rs
@@ -4,10 +4,14 @@ use std::{
     cmp::Ordering,
     fmt::{self, Display, Formatter},
     hash::{Hash, Hasher},
+    sync::Arc,
 };
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct Position {
+pub struct Position(Arc<PositionInner>);
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct PositionInner {
     path: String,
     line_number: usize,
     column_number: usize,
@@ -21,28 +25,31 @@ impl Position {
         column_number: usize,
         line: impl Into<String>,
     ) -> Self {
-        Self {
-            path: path.into(),
-            line_number,
-            column_number,
-            line: line.into(),
-        }
+        Self(
+            PositionInner {
+                path: path.into(),
+                line_number,
+                column_number,
+                line: line.into(),
+            }
+            .into(),
+        )
     }
 
     pub fn path(&self) -> &str {
-        &self.path
+        &self.0.path
     }
 
     pub fn line_number(&self) -> usize {
-        self.line_number
+        self.0.line_number
     }
 
     pub fn column_number(&self) -> usize {
-        self.column_number
+        self.0.column_number
     }
 
     pub fn line(&self) -> &str {
-        &self.line
+        &self.0.line
     }
 }
 


### PR DESCRIPTION
# Benchmark

## Before

```
> hyperfine -w 10 'pen compile-prelude --target aarch64-apple-darwin /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/packages/pen_prelude/Map.pen /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/objects/Map_eca1efc0cf2dc7fa.bc /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/objects/Map_eca1efc0cf2dc7f'
Benchmark 1: pen compile-prelude --target aarch64-apple-darwin /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/packages/pen_prelude/Map.pen /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/objects/Map_eca1efc0cf2dc7fa.bc /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/objects/Map_eca1efc0cf2dc7f
  Time (mean ± σ):     165.8 ms ±   1.5 ms    [User: 155.6 ms, System: 8.1 ms]
  Range (min … max):   164.2 ms … 170.7 ms    17 runs
```

## After

```
> hyperfine -w 10 'pen compile-prelude --target aarch64-apple-darwin /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/packages/pen_prelude/Map.pen /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/objects/Map_eca1efc0cf2dc7fa.bc /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/objects/Map_eca1efc0cf2dc7f'
Benchmark 1: pen compile-prelude --target aarch64-apple-darwin /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/packages/pen_prelude/Map.pen /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/objects/Map_eca1efc0cf2dc7fa.bc /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/objects/Map_eca1efc0cf2dc7f
  Time (mean ± σ):     145.3 ms ±   0.6 ms    [User: 135.5 ms, System: 8.0 ms]
  Range (min … max):   144.2 ms … 147.0 ms    20 runs
```