### PR TITLE
Optimize MIR type data structure

### DIFF
--- a/lib/hir-mir/src/snapshots/hir_mir__built_in_call__tests__compile_debug.snap
+++ b/lib/hir-mir/src/snapshots/hir_mir__built_in_call__tests__compile_debug.snap
@@ -5,12 +5,14 @@ expression: "compile_call(&Call::new(Some(types::Function::new(vec![types :: Byt
 Ok(
     Call(
         Call {
-            type_: Function {
-                arguments: [
-                    ByteString,
-                ],
-                result: None,
-            },
+            type_: Function(
+                FunctionInner {
+                    arguments: [
+                        ByteString,
+                    ],
+                    result: None,
+                },
+            ),
             function: Variable(
                 Variable {
                     name: "__debug",
@@ -19,12 +21,14 @@ Ok(
             arguments: [
                 Call(
                     Call {
-                        type_: Function {
-                            arguments: [
-                                Variant,
-                            ],
-                            result: ByteString,
-                        },
+                        type_: Function(
+                            FunctionInner {
+                                arguments: [
+                                    Variant,
+                                ],
+                                result: ByteString,
+                            },
+                        ),
                         function: RecordField(
                             RecordField {
                                 type_: Record {
@@ -33,14 +37,16 @@ Ok(
                                 index: 0,
                                 record: Call(
                                     Call {
-                                        type_: Function {
-                                            arguments: [],
-                                            result: Record(
-                                                Record {
-                                                    name: "hir:type_information:record",
-                                                },
-                                            ),
-                                        },
+                                        type_: Function(
+                                            FunctionInner {
+                                                arguments: [],
+                                                result: Record(
+                                                    Record {
+                                                        name: "hir:type_information:record",
+                                                    },
+                                                ),
+                                            },
+                                        ),
                                         function: TypeInformationFunction(
                                             TypeInformationFunction {
                                                 variant: Variant(

--- a/lib/mir/src/types/function.rs
+++ b/lib/mir/src/types/function.rs
@@ -2,17 +2,23 @@ use super::type_::Type;
 use std::sync::Arc;
 
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct Function {
+pub struct Function(Arc<FunctionInner>);
+
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+struct FunctionInner {
     arguments: Vec<Type>,
-    result: Arc<Type>,
+    result: Type,
 }
 
 impl Function {
     pub fn new(arguments: Vec<Type>, result: impl Into<Type>) -> Self {
-        Self {
-            arguments,
-            result: result.into().into(),
-        }
+        Self(
+            FunctionInner {
+                arguments,
+                result: result.into().into(),
+            }
+            .into(),
+        )
     }
 
     pub fn arguments(&self) -> &[Type] {

--- a/lib/mir/src/types/function.rs
+++ b/lib/mir/src/types/function.rs
@@ -15,7 +15,7 @@ impl Function {
         Self(
             FunctionInner {
                 arguments,
-                result: result.into().into(),
+                result: result.into(),
             }
             .into(),
         )

--- a/lib/mir/src/types/function.rs
+++ b/lib/mir/src/types/function.rs
@@ -22,10 +22,10 @@ impl Function {
     }
 
     pub fn arguments(&self) -> &[Type] {
-        &self.arguments
+        &self.0.arguments
     }
 
     pub fn result(&self) -> &Type {
-        &self.result
+        &self.0.result
     }
 }

--- a/lib/mir/src/types/record.rs
+++ b/lib/mir/src/types/record.rs
@@ -1,11 +1,15 @@
+use std::sync::Arc;
+
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct Record {
-    name: String,
+    name: Arc<str>,
 }
 
 impl Record {
     pub fn new(name: impl Into<String>) -> Self {
-        Self { name: name.into() }
+        Self {
+            name: name.into().into(),
+        }
     }
 
     pub fn name(&self) -> &str {


### PR DESCRIPTION
# Benchmark

## Before

```
> hyperfine -w 10 'pen compile-prelude --target aarch64-apple-darwin /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/packages/pen_prelude/Map.pen /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/objects/Map_eca1efc0cf2dc7fa.bc /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/objects/Map_eca1efc0cf2dc7f'
Benchmark 1: pen compile-prelude --target aarch64-apple-darwin /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/packages/pen_prelude/Map.pen /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/objects/Map_eca1efc0cf2dc7fa.bc /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/objects/Map_eca1efc0cf2dc7f
  Time (mean ± σ):     143.5 ms ±   1.0 ms    [User: 134.3 ms, System: 7.3 ms]
  Range (min … max):   141.0 ms … 145.3 ms    20 runs
```

## After

```
> hyperfine -w 10 'pen compile-prelude --target aarch64-apple-darwin /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/packages/pen_prelude/Map.pen /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/objects/Map_eca1efc0cf2dc7fa.bc /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/objects/Map_eca1efc0cf2dc7f'
Benchmark 1: pen compile-prelude --target aarch64-apple-darwin /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/packages/pen_prelude/Map.pen /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/objects/Map_eca1efc0cf2dc7fa.bc /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/objects/Map_eca1efc0cf2dc7f
  Time (mean ± σ):     141.1 ms ±   1.2 ms    [User: 131.7 ms, System: 7.6 ms]
  Range (min … max):   138.8 ms … 143.2 ms    20 runs
```