### PR TITLE
Optimize MIR expression data structures

### DIFF
--- a/lib/hir-mir/src/snapshots/hir_mir__built_in_call__tests__compile_debug.snap
+++ b/lib/hir-mir/src/snapshots/hir_mir__built_in_call__tests__compile_debug.snap
@@ -4,75 +4,87 @@ expression: "compile_call(&Call::new(Some(types::Function::new(vec![types :: Byt
 ---
 Ok(
     Call(
-        Call {
-            type_: Function(
-                FunctionInner {
-                    arguments: [
-                        ByteString,
-                    ],
-                    result: None,
-                },
-            ),
-            function: Variable(
-                Variable {
-                    name: "__debug",
-                },
-            ),
-            arguments: [
-                Call(
-                    Call {
-                        type_: Function(
-                            FunctionInner {
-                                arguments: [
-                                    Variant,
-                                ],
-                                result: ByteString,
-                            },
-                        ),
-                        function: RecordField(
-                            RecordField {
-                                type_: Record {
-                                    name: "hir:type_information:record",
-                                },
-                                index: 0,
-                                record: Call(
-                                    Call {
-                                        type_: Function(
-                                            FunctionInner {
-                                                arguments: [],
-                                                result: Record(
-                                                    Record {
-                                                        name: "hir:type_information:record",
-                                                    },
-                                                ),
-                                            },
-                                        ),
-                                        function: TypeInformationFunction(
-                                            TypeInformationFunction {
-                                                variant: Variant(
-                                                    Variant {
-                                                        type_: None,
-                                                        payload: None,
-                                                    },
-                                                ),
-                                            },
-                                        ),
-                                        arguments: [],
-                                    },
-                                ),
-                            },
-                        ),
+        Call(
+            CallInner {
+                type_: Function(
+                    FunctionInner {
                         arguments: [
-                            Variant(
-                                Variant {
-                                    type_: None,
-                                    payload: None,
-                                },
-                            ),
+                            ByteString,
                         ],
+                        result: None,
                     },
                 ),
-            ],
-        },
+                function: Variable(
+                    Variable {
+                        name: "__debug",
+                    },
+                ),
+                arguments: [
+                    Call(
+                        Call(
+                            CallInner {
+                                type_: Function(
+                                    FunctionInner {
+                                        arguments: [
+                                            Variant,
+                                        ],
+                                        result: ByteString,
+                                    },
+                                ),
+                                function: RecordField(
+                                    RecordField(
+                                        RecordFieldInner {
+                                            type_: Record {
+                                                name: "hir:type_information:record",
+                                            },
+                                            index: 0,
+                                            record: Call(
+                                                Call(
+                                                    CallInner {
+                                                        type_: Function(
+                                                            FunctionInner {
+                                                                arguments: [],
+                                                                result: Record(
+                                                                    Record {
+                                                                        name: "hir:type_information:record",
+                                                                    },
+                                                                ),
+                                                            },
+                                                        ),
+                                                        function: TypeInformationFunction(
+                                                            TypeInformationFunction {
+                                                                variant: Variant(
+                                                                    Variant(
+                                                                        VariantInner {
+                                                                            type_: None,
+                                                                            payload: None,
+                                                                        },
+                                                                    ),
+                                                                ),
+                                                            },
+                                                        ),
+                                                        arguments: [],
+                                                    },
+                                                ),
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                arguments: [
+                                    Variant(
+                                        Variant(
+                                            VariantInner {
+                                                type_: None,
+                                                payload: None,
+                                            },
+                                        ),
+                                    ),
+                                ],
+                            },
+                        ),
+                    ),
+                ],
+            },
+        ),
     ),
 )

--- a/lib/mir/src/ir/arithmetic_operation.rs
+++ b/lib/mir/src/ir/arithmetic_operation.rs
@@ -2,10 +2,13 @@ use super::{arithmetic_operator::ArithmeticOperator, expression::Expression};
 use std::sync::Arc;
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct ArithmeticOperation {
+pub struct ArithmeticOperation(Arc<ArithmeticOperationInner>);
+
+#[derive(Clone, Debug, PartialEq)]
+struct ArithmeticOperationInner {
     operator: ArithmeticOperator,
-    lhs: Arc<Expression>,
-    rhs: Arc<Expression>,
+    lhs: Expression,
+    rhs: Expression,
 }
 
 impl ArithmeticOperation {
@@ -14,22 +17,25 @@ impl ArithmeticOperation {
         lhs: impl Into<Expression>,
         rhs: impl Into<Expression>,
     ) -> Self {
-        Self {
-            operator,
-            lhs: Arc::new(lhs.into()),
-            rhs: Arc::new(rhs.into()),
-        }
+        Self(
+            ArithmeticOperationInner {
+                operator,
+                lhs: (lhs.into()),
+                rhs: (rhs.into()),
+            }
+            .into(),
+        )
     }
 
     pub fn operator(&self) -> ArithmeticOperator {
-        self.operator
+        self.0.operator
     }
 
     pub fn lhs(&self) -> &Expression {
-        &self.lhs
+        &self.0.lhs
     }
 
     pub fn rhs(&self) -> &Expression {
-        &self.rhs
+        &self.0.rhs
     }
 }

--- a/lib/mir/src/ir/arithmetic_operation.rs
+++ b/lib/mir/src/ir/arithmetic_operation.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 #[derive(Clone, Debug, PartialEq)]
 pub struct ArithmeticOperation(Arc<ArithmeticOperationInner>);
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Debug, PartialEq)]
 struct ArithmeticOperationInner {
     operator: ArithmeticOperator,
     lhs: Expression,

--- a/lib/mir/src/ir/arithmetic_operation.rs
+++ b/lib/mir/src/ir/arithmetic_operation.rs
@@ -2,7 +2,7 @@ use super::{arithmetic_operator::ArithmeticOperator, expression::Expression};
 use std::rc::Rc;
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct ArithmeticOperation(Arc<ArithmeticOperationInner>);
+pub struct ArithmeticOperation(Rc<ArithmeticOperationInner>);
 
 #[derive(Debug, PartialEq)]
 struct ArithmeticOperationInner {

--- a/lib/mir/src/ir/byte_string.rs
+++ b/lib/mir/src/ir/byte_string.rs
@@ -1,12 +1,14 @@
+use std::sync::Arc;
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ByteString {
-    value: Vec<u8>,
+    value: Arc<[u8]>,
 }
 
 impl ByteString {
     pub fn new(value: impl Into<Vec<u8>>) -> Self {
         Self {
-            value: value.into(),
+            value: value.into().into(),
         }
     }
 

--- a/lib/mir/src/ir/byte_string.rs
+++ b/lib/mir/src/ir/byte_string.rs
@@ -1,8 +1,8 @@
-use std::sync::Arc;
+use std::rc::Rc;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ByteString {
-    value: Arc<[u8]>,
+    value: Rc<[u8]>,
 }
 
 impl ByteString {

--- a/lib/mir/src/ir/call.rs
+++ b/lib/mir/src/ir/call.rs
@@ -3,7 +3,7 @@ use crate::types;
 use std::rc::Rc;
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct Call(Arc<CallInner>);
+pub struct Call(Rc<CallInner>);
 
 #[derive(Debug, PartialEq)]
 struct CallInner {

--- a/lib/mir/src/ir/call.rs
+++ b/lib/mir/src/ir/call.rs
@@ -3,9 +3,12 @@ use crate::types;
 use std::sync::Arc;
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct Call {
+pub struct Call(Arc<CallInner>);
+
+#[derive(Debug, PartialEq)]
+struct CallInner {
     type_: types::Function,
-    function: Arc<Expression>,
+    function: Expression,
     arguments: Vec<Expression>,
 }
 
@@ -15,22 +18,25 @@ impl Call {
         function: impl Into<Expression>,
         arguments: Vec<Expression>,
     ) -> Self {
-        Self {
-            type_,
-            function: function.into().into(),
-            arguments,
-        }
+        Self(
+            CallInner {
+                type_,
+                function: function.into().into(),
+                arguments,
+            }
+            .into(),
+        )
     }
 
     pub fn type_(&self) -> &types::Function {
-        &self.type_
+        &self.0.type_
     }
 
     pub fn function(&self) -> &Expression {
-        &self.function
+        &self.0.function
     }
 
     pub fn arguments(&self) -> &[Expression] {
-        &self.arguments
+        &self.0.arguments
     }
 }

--- a/lib/mir/src/ir/call.rs
+++ b/lib/mir/src/ir/call.rs
@@ -21,7 +21,7 @@ impl Call {
         Self(
             CallInner {
                 type_,
-                function: function.into().into(),
+                function: function.into(),
                 arguments,
             }
             .into(),

--- a/lib/mir/src/ir/case.rs
+++ b/lib/mir/src/ir/case.rs
@@ -4,7 +4,7 @@ use super::{
 use std::rc::Rc;
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct Case(Arc<CaseInner>);
+pub struct Case(Rc<CaseInner>);
 
 #[derive(Debug, PartialEq)]
 struct CaseInner {

--- a/lib/mir/src/ir/case.rs
+++ b/lib/mir/src/ir/case.rs
@@ -4,8 +4,11 @@ use super::{
 use std::sync::Arc;
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct Case {
-    argument: Arc<Expression>,
+pub struct Case(Arc<CaseInner>);
+
+#[derive(Debug, PartialEq)]
+struct CaseInner {
+    argument: Expression,
     alternatives: Vec<Alternative>,
     default_alternative: Option<DefaultAlternative>,
 }
@@ -16,22 +19,25 @@ impl Case {
         alternatives: Vec<Alternative>,
         default_alternative: Option<DefaultAlternative>,
     ) -> Self {
-        Self {
-            argument: Arc::new(argument.into()),
-            alternatives,
-            default_alternative,
-        }
+        Self(
+            CaseInner {
+                argument: argument.into(),
+                alternatives,
+                default_alternative,
+            }
+            .into(),
+        )
     }
 
     pub fn argument(&self) -> &Expression {
-        &self.argument
+        &self.0.argument
     }
 
     pub fn alternatives(&self) -> &[Alternative] {
-        &self.alternatives
+        &self.0.alternatives
     }
 
     pub fn default_alternative(&self) -> Option<&DefaultAlternative> {
-        self.default_alternative.as_ref()
+        self.0.default_alternative.as_ref()
     }
 }

--- a/lib/mir/src/ir/clone_variables.rs
+++ b/lib/mir/src/ir/clone_variables.rs
@@ -4,24 +4,30 @@ use fnv::FnvHashMap;
 use std::sync::Arc;
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct CloneVariables {
+pub struct CloneVariables(Arc<CloneVariablesInner>);
+
+#[derive(Debug, PartialEq)]
+struct CloneVariablesInner {
     variables: FnvHashMap<String, Type>,
-    expression: Arc<Expression>,
+    expression: Expression,
 }
 
 impl CloneVariables {
     pub fn new(variables: FnvHashMap<String, Type>, expression: impl Into<Expression>) -> Self {
-        Self {
-            variables,
-            expression: expression.into().into(),
-        }
+        Self(
+            CloneVariablesInner {
+                variables,
+                expression: expression.into().into(),
+            }
+            .into(),
+        )
     }
 
     pub fn variables(&self) -> &FnvHashMap<String, Type> {
-        &self.variables
+        &self.0.variables
     }
 
     pub fn expression(&self) -> &Expression {
-        &self.expression
+        &self.0.expression
     }
 }

--- a/lib/mir/src/ir/clone_variables.rs
+++ b/lib/mir/src/ir/clone_variables.rs
@@ -17,7 +17,7 @@ impl CloneVariables {
         Self(
             CloneVariablesInner {
                 variables,
-                expression: expression.into().into(),
+                expression: expression.into(),
             }
             .into(),
         )

--- a/lib/mir/src/ir/clone_variables.rs
+++ b/lib/mir/src/ir/clone_variables.rs
@@ -4,7 +4,7 @@ use fnv::FnvHashMap;
 use std::rc::Rc;
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct CloneVariables(Arc<CloneVariablesInner>);
+pub struct CloneVariables(Rc<CloneVariablesInner>);
 
 #[derive(Debug, PartialEq)]
 struct CloneVariablesInner {

--- a/lib/mir/src/ir/comparison_operation.rs
+++ b/lib/mir/src/ir/comparison_operation.rs
@@ -2,7 +2,7 @@ use super::{comparison_operator::ComparisonOperator, expression::Expression};
 use std::rc::Rc;
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct ComparisonOperation(Arc<ComparisonOperationInner>);
+pub struct ComparisonOperation(Rc<ComparisonOperationInner>);
 
 #[derive(Debug, PartialEq)]
 struct ComparisonOperationInner {

--- a/lib/mir/src/ir/comparison_operation.rs
+++ b/lib/mir/src/ir/comparison_operation.rs
@@ -2,10 +2,13 @@ use super::{comparison_operator::ComparisonOperator, expression::Expression};
 use std::sync::Arc;
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct ComparisonOperation {
+pub struct ComparisonOperation(Arc<ComparisonOperationInner>);
+
+#[derive(Debug, PartialEq)]
+struct ComparisonOperationInner {
     operator: ComparisonOperator,
-    lhs: Arc<Expression>,
-    rhs: Arc<Expression>,
+    lhs: Expression,
+    rhs: Expression,
 }
 
 impl ComparisonOperation {
@@ -14,22 +17,25 @@ impl ComparisonOperation {
         lhs: impl Into<Expression>,
         rhs: impl Into<Expression>,
     ) -> Self {
-        Self {
-            operator,
-            lhs: Arc::new(lhs.into()),
-            rhs: Arc::new(rhs.into()),
-        }
+        Self(
+            ComparisonOperationInner {
+                operator,
+                lhs: (lhs.into()),
+                rhs: (rhs.into()),
+            }
+            .into(),
+        )
     }
 
     pub fn operator(&self) -> ComparisonOperator {
-        self.operator
+        self.0.operator
     }
 
     pub fn lhs(&self) -> &Expression {
-        &self.lhs
+        &self.0.lhs
     }
 
     pub fn rhs(&self) -> &Expression {
-        &self.rhs
+        &self.0.rhs
     }
 }

--- a/lib/mir/src/ir/drop_variables.rs
+++ b/lib/mir/src/ir/drop_variables.rs
@@ -17,7 +17,7 @@ impl DropVariables {
         Self(
             DropVariablesInner {
                 variables,
-                expression: expression.into().into(),
+                expression: expression.into(),
             }
             .into(),
         )

--- a/lib/mir/src/ir/drop_variables.rs
+++ b/lib/mir/src/ir/drop_variables.rs
@@ -4,7 +4,7 @@ use fnv::FnvHashMap;
 use std::rc::Rc;
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct DropVariables(Arc<DropVariablesInner>);
+pub struct DropVariables(Rc<DropVariablesInner>);
 
 #[derive(Debug, PartialEq)]
 struct DropVariablesInner {

--- a/lib/mir/src/ir/drop_variables.rs
+++ b/lib/mir/src/ir/drop_variables.rs
@@ -4,24 +4,30 @@ use fnv::FnvHashMap;
 use std::sync::Arc;
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct DropVariables {
+pub struct DropVariables(Arc<DropVariablesInner>);
+
+#[derive(Debug, PartialEq)]
+struct DropVariablesInner {
     variables: FnvHashMap<String, Type>,
-    expression: Arc<Expression>,
+    expression: Expression,
 }
 
 impl DropVariables {
     pub fn new(variables: FnvHashMap<String, Type>, expression: impl Into<Expression>) -> Self {
-        Self {
-            variables,
-            expression: expression.into().into(),
-        }
+        Self(
+            DropVariablesInner {
+                variables,
+                expression: expression.into().into(),
+            }
+            .into(),
+        )
     }
 
     pub fn variables(&self) -> &FnvHashMap<String, Type> {
-        &self.variables
+        &self.0.variables
     }
 
     pub fn expression(&self) -> &Expression {
-        &self.expression
+        &self.0.expression
     }
 }

--- a/lib/mir/src/ir/expression.rs
+++ b/lib/mir/src/ir/expression.rs
@@ -158,3 +158,14 @@ impl From<Variant> for Expression {
         Self::Variant(variant)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::mem::size_of;
+
+    #[test]
+    fn type_size() {
+        assert_eq!(size_of::<Expression>(), 3 * size_of::<usize>());
+    }
+}

--- a/lib/mir/src/ir/if_.rs
+++ b/lib/mir/src/ir/if_.rs
@@ -2,7 +2,7 @@ use super::expression::Expression;
 use std::rc::Rc;
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct If(Arc<IfInner>);
+pub struct If(Rc<IfInner>);
 
 #[derive(Debug, PartialEq)]
 struct IfInner {

--- a/lib/mir/src/ir/if_.rs
+++ b/lib/mir/src/ir/if_.rs
@@ -2,10 +2,13 @@ use super::expression::Expression;
 use std::sync::Arc;
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct If {
-    condition: Arc<Expression>,
-    then: Arc<Expression>,
-    else_: Arc<Expression>,
+pub struct If(Arc<IfInner>);
+
+#[derive(Clone, Debug, PartialEq)]
+struct IfInner {
+    condition: Expression,
+    then: Expression,
+    else_: Expression,
 }
 
 impl If {
@@ -14,22 +17,25 @@ impl If {
         then: impl Into<Expression>,
         else_: impl Into<Expression>,
     ) -> Self {
-        Self {
-            condition: Arc::new(condition.into()),
-            then: Arc::new(then.into()),
-            else_: Arc::new(else_.into()),
-        }
+        Self(
+            IfInner {
+                condition: (condition.into()),
+                then: (then.into()),
+                else_: (else_.into()),
+            }
+            .into(),
+        )
     }
 
     pub fn condition(&self) -> &Expression {
-        &self.condition
+        &self.0.condition
     }
 
     pub fn then(&self) -> &Expression {
-        &self.then
+        &self.0.then
     }
 
     pub fn else_(&self) -> &Expression {
-        &self.else_
+        &self.0.else_
     }
 }

--- a/lib/mir/src/ir/if_.rs
+++ b/lib/mir/src/ir/if_.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 #[derive(Clone, Debug, PartialEq)]
 pub struct If(Arc<IfInner>);
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Debug, PartialEq)]
 struct IfInner {
     condition: Expression,
     then: Expression,

--- a/lib/mir/src/ir/let_.rs
+++ b/lib/mir/src/ir/let_.rs
@@ -3,7 +3,7 @@ use crate::types::Type;
 use std::rc::Rc;
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct Let(Arc<LetInner>);
+pub struct Let(Rc<LetInner>);
 
 #[derive(Clone, Debug, PartialEq)]
 struct LetInner {

--- a/lib/mir/src/ir/let_.rs
+++ b/lib/mir/src/ir/let_.rs
@@ -3,11 +3,14 @@ use crate::types::Type;
 use std::sync::Arc;
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct Let {
+pub struct Let(Arc<LetInner>);
+
+#[derive(Clone, Debug, PartialEq)]
+struct LetInner {
     name: String,
     type_: Type,
-    bound_expression: Arc<Expression>,
-    expression: Arc<Expression>,
+    bound_expression: Expression,
+    expression: Expression,
 }
 
 impl Let {
@@ -17,27 +20,30 @@ impl Let {
         bound_expression: impl Into<Expression>,
         expression: impl Into<Expression>,
     ) -> Self {
-        Self {
-            name: name.into(),
-            type_: type_.into(),
-            bound_expression: bound_expression.into().into(),
-            expression: expression.into().into(),
-        }
+        Self(
+            LetInner {
+                name: name.into(),
+                type_: type_.into(),
+                bound_expression: bound_expression.into().into(),
+                expression: expression.into().into(),
+            }
+            .into(),
+        )
     }
 
     pub fn name(&self) -> &str {
-        &self.name
+        &self.0.name
     }
 
     pub fn type_(&self) -> &Type {
-        &self.type_
+        &self.0.type_
     }
 
     pub fn bound_expression(&self) -> &Expression {
-        &self.bound_expression
+        &self.0.bound_expression
     }
 
     pub fn expression(&self) -> &Expression {
-        &self.expression
+        &self.0.expression
     }
 }

--- a/lib/mir/src/ir/let_.rs
+++ b/lib/mir/src/ir/let_.rs
@@ -24,8 +24,8 @@ impl Let {
             LetInner {
                 name: name.into(),
                 type_: type_.into(),
-                bound_expression: bound_expression.into().into(),
-                expression: expression.into().into(),
+                bound_expression: bound_expression.into(),
+                expression: expression.into(),
             }
             .into(),
         )

--- a/lib/mir/src/ir/let_recursive.rs
+++ b/lib/mir/src/ir/let_recursive.rs
@@ -17,7 +17,7 @@ use std::rc::Rc;
 //   effectively.
 //   - e.g. list comprehension
 #[derive(Clone, Debug, PartialEq)]
-pub struct LetRecursive(Arc<LetRecursiveInner>);
+pub struct LetRecursive(Rc<LetRecursiveInner>);
 
 #[derive(Debug, PartialEq)]
 struct LetRecursiveInner {

--- a/lib/mir/src/ir/let_recursive.rs
+++ b/lib/mir/src/ir/let_recursive.rs
@@ -17,24 +17,30 @@ use std::sync::Arc;
 //   effectively.
 //   - e.g. list comprehension
 #[derive(Clone, Debug, PartialEq)]
-pub struct LetRecursive {
-    definition: Arc<FunctionDefinition>,
-    expression: Arc<Expression>,
+pub struct LetRecursive(Arc<LetRecursiveInner>);
+
+#[derive(Debug, PartialEq)]
+struct LetRecursiveInner {
+    definition: FunctionDefinition,
+    expression: Expression,
 }
 
 impl LetRecursive {
     pub fn new(definition: FunctionDefinition, expression: impl Into<Expression>) -> Self {
-        Self {
-            definition: definition.into(),
-            expression: Arc::new(expression.into()),
-        }
+        Self(
+            LetRecursiveInner {
+                definition: definition.into(),
+                expression: (expression.into()),
+            }
+            .into(),
+        )
     }
 
     pub fn definition(&self) -> &FunctionDefinition {
-        &self.definition
+        &self.0.definition
     }
 
     pub fn expression(&self) -> &Expression {
-        &self.expression
+        &self.0.expression
     }
 }

--- a/lib/mir/src/ir/let_recursive.rs
+++ b/lib/mir/src/ir/let_recursive.rs
@@ -29,7 +29,7 @@ impl LetRecursive {
     pub fn new(definition: FunctionDefinition, expression: impl Into<Expression>) -> Self {
         Self(
             LetRecursiveInner {
-                definition: definition.into(),
+                definition,
                 expression: (expression.into()),
             }
             .into(),

--- a/lib/mir/src/ir/record.rs
+++ b/lib/mir/src/ir/record.rs
@@ -1,9 +1,9 @@
 use super::expression::Expression;
 use crate::types;
-use std::sync::Arc;
+use std::rc::Rc;
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct Record(Arc<RecordInner>);
+pub struct Record(Rc<RecordInner>);
 
 #[derive(Debug, PartialEq)]
 struct RecordInner {

--- a/lib/mir/src/ir/record.rs
+++ b/lib/mir/src/ir/record.rs
@@ -1,22 +1,26 @@
 use super::expression::Expression;
 use crate::types;
+use std::sync::Arc;
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct Record {
+pub struct Record(Arc<RecordInner>);
+
+#[derive(Debug, PartialEq)]
+struct RecordInner {
     type_: types::Record,
     fields: Vec<Expression>,
 }
 
 impl Record {
     pub fn new(type_: types::Record, fields: Vec<Expression>) -> Self {
-        Self { type_, fields }
+        Self(RecordInner { type_, fields }.into())
     }
 
     pub fn type_(&self) -> &types::Record {
-        &self.type_
+        &self.0.type_
     }
 
     pub fn fields(&self) -> &[Expression] {
-        &self.fields
+        &self.0.fields
     }
 }

--- a/lib/mir/src/ir/record_field.rs
+++ b/lib/mir/src/ir/record_field.rs
@@ -3,30 +3,36 @@ use crate::types;
 use std::sync::Arc;
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct RecordField {
+pub struct RecordField(Arc<RecordFieldInner>);
+
+#[derive(Debug, PartialEq)]
+struct RecordFieldInner {
     type_: types::Record,
     index: usize,
-    record: Arc<Expression>,
+    record: Expression,
 }
 
 impl RecordField {
     pub fn new(type_: types::Record, index: usize, record: impl Into<Expression>) -> Self {
-        Self {
-            type_,
-            index,
-            record: record.into().into(),
-        }
+        Self(
+            RecordFieldInner {
+                type_,
+                index,
+                record: record.into().into(),
+            }
+            .into(),
+        )
     }
 
     pub fn type_(&self) -> &types::Record {
-        &self.type_
+        &self.0.type_
     }
 
     pub fn index(&self) -> usize {
-        self.index
+        self.0.index
     }
 
     pub fn record(&self) -> &Expression {
-        &self.record
+        &self.0.record
     }
 }

--- a/lib/mir/src/ir/record_field.rs
+++ b/lib/mir/src/ir/record_field.rs
@@ -3,7 +3,7 @@ use crate::types;
 use std::rc::Rc;
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct RecordField(Arc<RecordFieldInner>);
+pub struct RecordField(Rc<RecordFieldInner>);
 
 #[derive(Debug, PartialEq)]
 struct RecordFieldInner {

--- a/lib/mir/src/ir/record_field.rs
+++ b/lib/mir/src/ir/record_field.rs
@@ -18,7 +18,7 @@ impl RecordField {
             RecordFieldInner {
                 type_,
                 index,
-                record: record.into().into(),
+                record: record.into(),
             }
             .into(),
         )

--- a/lib/mir/src/ir/record_update.rs
+++ b/lib/mir/src/ir/record_update.rs
@@ -3,7 +3,7 @@ use crate::types;
 use std::rc::Rc;
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct RecordUpdate(Arc<RecordUpdateInner>);
+pub struct RecordUpdate(Rc<RecordUpdateInner>);
 
 #[derive(Debug, PartialEq)]
 struct RecordUpdateInner {

--- a/lib/mir/src/ir/record_update.rs
+++ b/lib/mir/src/ir/record_update.rs
@@ -3,9 +3,12 @@ use crate::types;
 use std::sync::Arc;
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct RecordUpdate {
+pub struct RecordUpdate(Arc<RecordUpdateInner>);
+
+#[derive(Debug, PartialEq)]
+struct RecordUpdateInner {
     type_: types::Record,
-    record: Arc<Expression>,
+    record: Expression,
     fields: Vec<RecordUpdateField>,
 }
 
@@ -15,22 +18,25 @@ impl RecordUpdate {
         record: impl Into<Expression>,
         fields: Vec<RecordUpdateField>,
     ) -> Self {
-        Self {
-            type_,
-            record: record.into().into(),
-            fields,
-        }
+        Self(
+            RecordUpdateInner {
+                type_,
+                record: record.into(),
+                fields,
+            }
+            .into(),
+        )
     }
 
     pub fn type_(&self) -> &types::Record {
-        &self.type_
+        &self.0.type_
     }
 
     pub fn record(&self) -> &Expression {
-        &self.record
+        &self.0.record
     }
 
     pub fn fields(&self) -> &[RecordUpdateField] {
-        &self.fields
+        &self.0.fields
     }
 }

--- a/lib/mir/src/ir/string_concatenation.rs
+++ b/lib/mir/src/ir/string_concatenation.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct StringConcatenation {
-    operands: Arc<Vec<Expression>>,
+    operands: Arc<[Expression]>,
 }
 
 impl StringConcatenation {

--- a/lib/mir/src/ir/string_concatenation.rs
+++ b/lib/mir/src/ir/string_concatenation.rs
@@ -3,7 +3,7 @@ use std::rc::Rc;
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct StringConcatenation {
-    operands: Arc<[Expression]>,
+    operands: Rc<[Expression]>,
 }
 
 impl StringConcatenation {

--- a/lib/mir/src/ir/synchronize.rs
+++ b/lib/mir/src/ir/synchronize.rs
@@ -3,24 +3,30 @@ use crate::types::Type;
 use std::sync::Arc;
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct Synchronize {
+pub struct Synchronize(Arc<SynchronizeInner>);
+
+#[derive(Debug, PartialEq)]
+struct SynchronizeInner {
     type_: Type,
-    expression: Arc<Expression>,
+    expression: Expression,
 }
 
 impl Synchronize {
     pub fn new(type_: impl Into<Type>, expression: impl Into<Expression>) -> Self {
-        Self {
-            type_: type_.into(),
-            expression: expression.into().into(),
-        }
+        Self(
+            SynchronizeInner {
+                type_: type_.into(),
+                expression: expression.into().into(),
+            }
+            .into(),
+        )
     }
 
     pub fn type_(&self) -> &Type {
-        &self.type_
+        &self.0.type_
     }
 
     pub fn expression(&self) -> &Expression {
-        &self.expression
+        &self.0.expression
     }
 }

--- a/lib/mir/src/ir/synchronize.rs
+++ b/lib/mir/src/ir/synchronize.rs
@@ -3,7 +3,7 @@ use crate::types::Type;
 use std::rc::Rc;
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct Synchronize(Arc<SynchronizeInner>);
+pub struct Synchronize(Rc<SynchronizeInner>);
 
 #[derive(Debug, PartialEq)]
 struct SynchronizeInner {

--- a/lib/mir/src/ir/synchronize.rs
+++ b/lib/mir/src/ir/synchronize.rs
@@ -16,7 +16,7 @@ impl Synchronize {
         Self(
             SynchronizeInner {
                 type_: type_.into(),
-                expression: expression.into().into(),
+                expression: expression.into(),
             }
             .into(),
         )

--- a/lib/mir/src/ir/try_operation.rs
+++ b/lib/mir/src/ir/try_operation.rs
@@ -5,7 +5,7 @@ use std::rc::Rc;
 // A try operation matches an operand with a type and returns it from a function
 // if it matches.
 #[derive(Clone, Debug, PartialEq)]
-pub struct TryOperation(Arc<TryOperationInner>);
+pub struct TryOperation(Rc<TryOperationInner>);
 
 #[derive(Debug, PartialEq)]
 struct TryOperationInner {

--- a/lib/mir/src/ir/try_operation.rs
+++ b/lib/mir/src/ir/try_operation.rs
@@ -5,11 +5,14 @@ use std::sync::Arc;
 // A try operation matches an operand with a type and returns it from a function
 // if it matches.
 #[derive(Clone, Debug, PartialEq)]
-pub struct TryOperation {
-    operand: Arc<Expression>,
+pub struct TryOperation(Arc<TryOperationInner>);
+
+#[derive(Debug, PartialEq)]
+struct TryOperationInner {
+    operand: Expression,
     name: String,
     type_: Type,
-    then: Arc<Expression>,
+    then: Expression,
 }
 
 impl TryOperation {
@@ -19,27 +22,30 @@ impl TryOperation {
         type_: impl Into<Type>,
         then: impl Into<Expression>,
     ) -> Self {
-        Self {
-            operand: operand.into().into(),
-            name: name.into(),
-            type_: type_.into(),
-            then: then.into().into(),
-        }
+        Self(
+            TryOperationInner {
+                operand: operand.into().into(),
+                name: name.into(),
+                type_: type_.into(),
+                then: then.into().into(),
+            }
+            .into(),
+        )
     }
 
     pub fn operand(&self) -> &Expression {
-        &self.operand
+        &self.0.operand
     }
 
     pub fn name(&self) -> &str {
-        &self.name
+        &self.0.name
     }
 
     pub fn type_(&self) -> &Type {
-        &self.type_
+        &self.0.type_
     }
 
     pub fn then(&self) -> &Expression {
-        &self.then
+        &self.0.then
     }
 }

--- a/lib/mir/src/ir/try_operation.rs
+++ b/lib/mir/src/ir/try_operation.rs
@@ -24,10 +24,10 @@ impl TryOperation {
     ) -> Self {
         Self(
             TryOperationInner {
-                operand: operand.into().into(),
+                operand: operand.into(),
                 name: name.into(),
                 type_: type_.into(),
-                then: then.into().into(),
+                then: then.into(),
             }
             .into(),
         )

--- a/lib/mir/src/ir/variable.rs
+++ b/lib/mir/src/ir/variable.rs
@@ -1,11 +1,15 @@
+use std::sync::Arc;
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Variable {
-    name: String,
+    name: Arc<str>,
 }
 
 impl Variable {
     pub fn new(name: impl Into<String>) -> Self {
-        Self { name: name.into() }
+        Self {
+            name: name.into().into(),
+        }
     }
 
     pub fn name(&self) -> &str {

--- a/lib/mir/src/ir/variable.rs
+++ b/lib/mir/src/ir/variable.rs
@@ -1,8 +1,8 @@
-use std::sync::Arc;
+use std::rc::Rc;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Variable {
-    name: Arc<str>,
+    name: Rc<str>,
 }
 
 impl Variable {

--- a/lib/mir/src/ir/variant.rs
+++ b/lib/mir/src/ir/variant.rs
@@ -16,7 +16,7 @@ impl Variant {
         Self(
             VariantInner {
                 type_: type_.into(),
-                payload: payload.into().into(),
+                payload: payload.into(),
             }
             .into(),
         )

--- a/lib/mir/src/ir/variant.rs
+++ b/lib/mir/src/ir/variant.rs
@@ -3,7 +3,7 @@ use crate::types::Type;
 use std::rc::Rc;
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct Variant(Arc<VariantInner>);
+pub struct Variant(Rc<VariantInner>);
 
 #[derive(Debug, PartialEq)]
 struct VariantInner {

--- a/lib/mir/src/ir/variant.rs
+++ b/lib/mir/src/ir/variant.rs
@@ -3,24 +3,30 @@ use crate::types::Type;
 use std::sync::Arc;
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct Variant {
+pub struct Variant(Arc<VariantInner>);
+
+#[derive(Debug, PartialEq)]
+struct VariantInner {
     type_: Type,
-    payload: Arc<Expression>,
+    payload: Expression,
 }
 
 impl Variant {
     pub fn new(type_: impl Into<Type>, payload: impl Into<Expression>) -> Self {
-        Self {
-            type_: type_.into(),
-            payload: payload.into().into(),
-        }
+        Self(
+            VariantInner {
+                type_: type_.into(),
+                payload: payload.into().into(),
+            }
+            .into(),
+        )
     }
 
     pub fn type_(&self) -> &Type {
-        &self.type_
+        &self.0.type_
     }
 
     pub fn payload(&self) -> &Expression {
-        &self.payload
+        &self.0.payload
     }
 }

--- a/lib/mir/src/types/record.rs
+++ b/lib/mir/src/types/record.rs
@@ -2,7 +2,7 @@ use std::rc::Rc;
 
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct Record {
-    name: Rc<str>,
+    name: Rc<String>,
 }
 
 impl Record {

--- a/lib/mir/src/types/type_.rs
+++ b/lib/mir/src/types/type_.rs
@@ -38,3 +38,14 @@ impl From<Record> for Type {
         Self::Record(record)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::mem::size_of;
+
+    #[test]
+    fn type_size() {
+        assert_eq!(size_of::<Type>(), 2 * size_of::<usize>());
+    }
+}


### PR DESCRIPTION
# Benchmark

```
> hyperfine -w 10 '~/worktree/f0fbb0dfcebc328b/target/release/pen compile-prelude --target aarch64-apple-darwin /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/packages/pen_prelude/Map.pen /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/objects/Map_eca1efc0cf2dc7fa.bc /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/objects/Map_eca1efc0cf2dc7f' '~/src/github.com/pen-lang/pen/target/release/pen compile-prelude --target aarch64-apple-darwin /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/packages/pen_prelude/Map.pen /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/objects/Map_eca1efc0cf2dc7fa.bc /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/objects/Map_eca1efc0cf2dc7f'
Benchmark 1: ~/worktree/f0fbb0dfcebc328b/target/release/pen compile-prelude --target aarch64-apple-darwin /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/packages/pen_prelude/Map.pen /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/objects/Map_eca1efc0cf2dc7fa.bc /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/objects/Map_eca1efc0cf2dc7f
  Time (mean ± σ):     144.9 ms ±   0.6 ms    [User: 135.3 ms, System: 7.8 ms]
  Range (min … max):   144.3 ms … 146.2 ms    20 runs

Benchmark 2: ~/src/github.com/pen-lang/pen/target/release/pen compile-prelude --target aarch64-apple-darwin /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/packages/pen_prelude/Map.pen /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/objects/Map_eca1efc0cf2dc7fa.bc /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/objects/Map_eca1efc0cf2dc7f
  Time (mean ± σ):     143.5 ms ±   0.4 ms    [User: 134.2 ms, System: 7.4 ms]
  Range (min … max):   142.9 ms … 144.3 ms    20 runs

Summary
  '~/src/github.com/pen-lang/pen/target/release/pen compile-prelude --target aarch64-apple-darwin /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/packages/pen_prelude/Map.pen /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/objects/Map_eca1efc0cf2dc7fa.bc /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/objects/Map_eca1efc0cf2dc7f' ran
    1.01 ± 0.00 times faster than '~/worktree/f0fbb0dfcebc328b/target/release/pen compile-prelude --target aarch64-apple-darwin /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/packages/pen_prelude/Map.pen /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/objects/Map_eca1efc0cf2dc7fa.bc /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/objects/Map_eca1efc0cf2dc7f'
```

# Updated

```
> hyperfine -w 10 '~/pen-main compile-prelude --target aarch64-apple-darwin /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/packages/pen_prelude/Map.pen /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/objects/Map_eca1efc0cf2dc7fa.bc /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/objects/Map_eca1efc0cf2dc7f' 'pen compile-prelude --target aarch64-apple-darwin /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/packages/pen_prelude/Map.pen /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/objects/Map_eca1efc0cf2dc7fa.bc /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/objects/Map_eca1efc0cf2dc7f'
Benchmark 1: ~/pen-main compile-prelude --target aarch64-apple-darwin /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/packages/pen_prelude/Map.pen /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/objects/Map_eca1efc0cf2dc7fa.bc /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/objects/Map_eca1efc0cf2dc7f
  Time (mean ± σ):      98.4 ms ±   0.5 ms    [User: 91.1 ms, System: 5.2 ms]
  Range (min … max):    97.6 ms …  99.7 ms    29 runs

Benchmark 2: pen compile-prelude --target aarch64-apple-darwin /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/packages/pen_prelude/Map.pen /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/objects/Map_eca1efc0cf2dc7fa.bc /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/objects/Map_eca1efc0cf2dc7f
  Time (mean ± σ):      97.8 ms ±   0.3 ms    [User: 90.6 ms, System: 5.1 ms]
  Range (min … max):    97.2 ms …  98.4 ms    29 runs

Summary
  'pen compile-prelude --target aarch64-apple-darwin /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/packages/pen_prelude/Map.pen /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/objects/Map_eca1efc0cf2dc7fa.bc /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/objects/Map_eca1efc0cf2dc7f' ran
    1.01 ± 0.01 times faster than '~/pen-main compile-prelude --target aarch64-apple-darwin /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/packages/pen_prelude/Map.pen /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/objects/Map_eca1efc0cf2dc7fa.bc /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/objects/Map_eca1efc0cf2dc7f'
```