### PR TITLE
Disallow CPS stack pointer alias for further optimization oppotunities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -266,7 +266,7 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 [[package]]
 name = "fmm"
 version = "0.1.0"
-source = "git+https://github.com/raviqqe/fmm?branch=main#06c823c4fafa8bcaa06fabb2cd515b0ae1a0003d"
+source = "git+https://github.com/raviqqe/fmm?branch=main#a51ae625dc648431eb998ab00e72485ebdd83e05"
 dependencies = [
  "fnv",
  "indexmap",
@@ -278,7 +278,7 @@ dependencies = [
 [[package]]
 name = "fmm-c"
 version = "0.1.0"
-source = "git+https://github.com/raviqqe/fmm?branch=main#06c823c4fafa8bcaa06fabb2cd515b0ae1a0003d"
+source = "git+https://github.com/raviqqe/fmm?branch=main#a51ae625dc648431eb998ab00e72485ebdd83e05"
 dependencies = [
  "fmm",
  "fnv",
@@ -288,7 +288,7 @@ dependencies = [
 [[package]]
 name = "fmm-llvm"
 version = "0.1.0"
-source = "git+https://github.com/raviqqe/fmm?branch=main#06c823c4fafa8bcaa06fabb2cd515b0ae1a0003d"
+source = "git+https://github.com/raviqqe/fmm?branch=main#a51ae625dc648431eb998ab00e72485ebdd83e05"
 dependencies = [
  "fmm",
  "fnv",

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Currently, Pen does not use [delimited continuations](https://en.wikipedia.org/w
 
 Pen implements [the Perceus reference counting][perceus] as its GC. Thanks to the state-of-the-art ownership-based RC algorithm, programs written in Pen performs much less than traditional RC where every data transfer or mutation requires counting operations. In addition, the algorithm reduces heap allocations significantly for records behind unique references, which brings practical performance without introducing unsafe mutability.
 
-See also [How to Implement the Perceus Reference Counting Garbage Collection](https://hackernoon.com/how-to-implement-the-perceus-reference-counting-garbage-collection).
+See also [How to Implement the Perceus Reference Counting Garbage Collection](https://dev.to/raviqqe/implementing-the-perceus-reference-counting-gc-5662).
 
 ### Inductive values
 

--- a/benchmark/pen/continuation/main.pen
+++ b/benchmark/pen/continuation/main.pen
@@ -1,0 +1,31 @@
+import Os'File
+
+main = \(ctx context) none {
+  loop(10000000)
+
+  none
+}
+
+loop = \(x number) none {
+  if x == 0 {
+    none
+  } else {
+    add(x, x, x)
+    loop(x - 1)
+  }
+}
+
+add = \(x number, y number, z number) number {
+  v1 = value()
+  v2 = value()
+  v3 = value()
+  w1 = value()
+  w2 = value()
+  w3 = value()
+
+  v1 + v2 + v3 + x + y + z + w1 + w2 + w3
+}
+
+value = \() number {
+  42
+}

--- a/benchmark/pen/continuation/pen.json
+++ b/benchmark/pen/continuation/pen.json
@@ -1,0 +1,6 @@
+{
+  "type": "application",
+  "dependencies": {
+    "Os": "pen:///os"
+  }
+}


### PR DESCRIPTION
# Benchmark

- Package: `benchmark/pen/continuation`
- This includes optimization by:
  - https://github.com/raviqqe/fmm/pull/409
  - https://github.com/raviqqe/fmm/pull/413
  - https://github.com/raviqqe/fmm/pull/417

```
> hyperfine -w 3 ./app-old ./app-new
Benchmark 1: ./app-old
  Time (mean ± σ):     524.3 ms ±   0.4 ms    [User: 469.0 ms, System: 3.3 ms]
  Range (min … max):   523.9 ms … 525.0 ms    10 runs

Benchmark 2: ./app-new
  Time (mean ± σ):     518.6 ms ±   0.9 ms    [User: 463.9 ms, System: 3.5 ms]
  Range (min … max):   517.0 ms … 520.0 ms    10 runs

Summary
  './app-new' ran
    1.01 ± 0.00 times faster than './app-old'

~ 14s
> hyperfine -w 3 ./app-old ./app-new
Benchmark 1: ./app-old
  Time (mean ± σ):     524.3 ms ±   0.9 ms    [User: 469.0 ms, System: 3.4 ms]
  Range (min … max):   523.2 ms … 526.0 ms    10 runs

Benchmark 2: ./app-new
  Time (mean ± σ):     518.7 ms ±   0.4 ms    [User: 463.8 ms, System: 3.6 ms]
  Range (min … max):   518.0 ms … 519.4 ms    10 runs

Summary
  './app-new' ran
    1.01 ± 0.00 times faster than './app-old'
```