### PR TITLE
ci: release assets for darwin/amd64

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,6 +30,7 @@ jobs:
         os:
           - ubuntu-22.04
           - macos-14
+          - macos-13
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Close #2327

The pull request https://github.com/pen-lang/pen/pull/2323 changed the runner from macos-latest to macos-14.
macos-13 and macos-latest are darwin/amd64 but macos-14 is darwin/arm64.
So at v0.6.7 https://github.com/pen-lang/pen/releases/tag/v0.6.7 the asset for darwin/arm64 was released instead of darwin/amd64.
To release assets for darwin/amd64, this pull request adds macos-13 to the build matrix.