### PR TITLE
ci: skip pushing docker images if pull requests are sent from fork repositories

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -25,6 +25,6 @@ jobs:
       - uses: docker/build-push-action@v5
         with:
           context: .
-          push: true
+          push: ${{ github.event_name != 'pull_request' || ! github.event.pull_request.head.repo.fork }}
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}


### PR DESCRIPTION
https://github.com/pen-lang/pen/pull/2326#issuecomment-1960658444

The push of docker images failed because GitHub Actions tokens don't have the write permission if pull requests are sent from fork repositories.

So this pull request skip pushing docker images if pull requests are sent from fork repositories.

## Test

The job passed.

https://github.com/pen-lang/pen/actions/runs/8014083453/job/21892121705?pr=2328#step:5:4

```
push: false
```