### PR TITLE
fix: reject unsupported Arc payload alignment

### DIFF
--- a/lib/ffi/src/arc.rs
+++ b/lib/ffi/src/arc.rs
@@ -20,6 +20,11 @@ pub struct Arc<T> {
 
 impl<T> Arc<T> {
     pub fn new(payload: T) -> Self {
+        assert!(
+            core::mem::align_of::<T>() <= core::mem::align_of::<core::sync::atomic::AtomicIsize>(),
+            "Arc<T> does not support payload alignment greater than AtomicIsize"
+        );
+        
         let mut block = ArcBlock::new(Layout::new::<T>());
 
         unsafe { write(block.ptr_mut() as *mut T, payload) };


### PR DESCRIPTION
Fixes #2709 .

Hi, thanks for maintaining this project.

`Arc<T>::new` writes the payload into storage allocated by `ArcBlock`. For payload types with an alignment greater than the block currently supports, such as `i128` on x86_64, this can reach `ptr::write` with an insufficiently aligned pointer and abort due to an unsafe precondition violation.

This PR adds an explicit alignment check before the unsafe write. The change keeps the current allocation layout unchanged, but makes unsupported payload alignments fail predictably with a Rust panic instead of reaching the unsafe precondition abort.

