### PR TITLE
fix: reject oversized FFI allocations

### DIFF
--- a/lib/ffi/src/arc/arc_buffer.rs
+++ b/lib/ffi/src/arc/arc_buffer.rs
@@ -15,6 +15,10 @@ struct ArcBufferInner {
 
 impl ArcBuffer {
     pub fn new(length: usize) -> Self {
+        assert!(
+            length <= (1usize << 40),
+            "ArcBuffer length is too large"
+        );
         Self {
             block: if length == 0 {
                 ArcBlock::new(Layout::from_size_align(0, 1).unwrap())

--- a/lib/ffi/src/cps/stack.rs
+++ b/lib/ffi/src/cps/stack.rs
@@ -14,6 +14,10 @@ pub struct Stack {
 
 impl Stack {
     pub fn new(capacity: usize) -> Self {
+        assert!(
+            capacity <= ((1usize << 40) / CAPACITY_MULTIPLIER),
+            "Stack capacity is too large"
+        );
         let layout = Self::get_layout(capacity).pad_to_align();
 
         Self {


### PR DESCRIPTION
Fixes #2710.

Hi, thanks for maintaining this project.

`ArcBuffer::new` and `cps::Stack::new` are public constructors that currently pass user-provided lengths/capacities into raw allocation paths. Extremely large values can lead to allocator aborts, sanitizer failures, or resource exhaustion before the APIs fail in a predictable Rust-side way.

This PR adds lightweight bounds checks directly in both constructors. The public API shape is unchanged; oversized inputs now fail with a clear Rust panic instead of reaching a huge raw allocation request.