### PR TITLE
Restore `rust-toolchain` group

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -20,6 +20,10 @@ updates:
       - /cmd/test
       - /packages/*/ffi
       - /packages/os/ffi/*
+    groups:
+      rust-toolchain:
+        patterns:
+          - "*"
     schedule:
       interval: daily
   - package-ecosystem: cargo


### PR DESCRIPTION
Without a group, Dependabot opens one pull request per directory, and each
one moves a single `rust-toolchain.toml` while the other 13 stay behind. Only
the root file lists the `clippy` and `rustfmt` components, so both linters
break on the channel that lacks them, and parallel package builds race each
other installing the second toolchain.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015hXahFXM3r5wc1QYUvjuiP
